### PR TITLE
feat: overlay-mini-kit 모달 구현, 북마크 입력하는 모달 구현

### DIFF
--- a/TODO1.md
+++ b/TODO1.md
@@ -1,0 +1,135 @@
+# 🚀 스마트 북마크 기능 구현 로드맵 (Smart Bookmark Implementation)
+
+## 🏗️ Phase 1: Shared UI - 공통 모달 시스템 구축
+
+- [ ] `src/shared/ui/Modal.tsx` 제작 (애니메이션, 포털, 접근성 지원)
+- [ ] 모바일 대응을 위한 Bottom-Sheet 스타일 UI 적용
+- [ ] 모달 전역 상태 관리 (Zustand) 또는 Context API 설정
+
+## 🏗️ Phase 2: Entity & API - 북마크 데이터 레이어
+
+- [ ] `src/entities/bookmark/model/types.ts`: 북마크 인터페이스 정의 (id, url, title, summary, tags, created_at 등)
+- [ ] `src/entities/bookmark/api/create-bookmark.ts`: 북마크 생성 API 연동 함수 작성
+- [ ] 서버 사이드 `process-url` API 고도화 (AI 요약 및 메타데이터 추출 로직 연결)
+
+## 🏗️ Phase 3: Feature - 북마크 추가 기능 (`add-bookmark`)
+
+- [ ] `src/features/add-bookmark/ui/AddBookmarkModal.tsx` 개발
+  - [ ] URL 입력 필드 및 실시간 유효성 검사
+  - [ ] URL 입력 시 AI 자동 분석 트리거 (로딩 스켈레톤 표시)
+  - [ ] AI 분석 결과(제목, 요약, 태그) 미리보기 및 수정 기능
+- [ ] `src/features/add-bookmark/model/use-add-bookmark.ts`: 추가 로직용 커스텀 훅 구현
+
+## 🏗️ Phase 4: Integration - 헤더 연동 및 UX 연결
+
+- [ ] `src/components/layout/Header.tsx`의 '북마크 추가' 버튼과 모달 연결
+- [ ] 북마크 추가 성공 시 목록 실시간 업데이트(Optimistic Update 또는 Refetch) 구현
+- [ ] 추가 성공 시 Toast 메시지 알림 처리
+
+## 🏗️ Phase 5: Business Logic - 비회원 가드 (Guest Guard)
+
+- [ ] 비회원(Guest) 여부 판별 로직 강화
+- [ ] 북마크 저장 전 현재 개수 체크 (최대 5개 제한)
+- [ ] 5개 초과 시 '로그인 유도' 모달 또는 팝업 표시 로직 구현
+- [ ] 게스트 데이터를 정식 계정으로 이전하는 마이그레이션 로직 준비
+
+## 🏗️ Phase 6: UX Polish & AI 안정화
+
+- [ ] AI 분석 중 화려한 로딩 애니메이션 추가
+- [ ] 분석 실패 시(크롤링 차단 등) 수동 입력 모드 전환 지원
+- [ ] 다크 모드에서의 모달 스타일 정밀 조정
+      1단계 - 이미 아는 것 (확인용)
+      useState, useReducer 차이
+      → useState : 단순한 값 하나
+      → useReducer: 여러 액션으로 복잡한 상태 관리
+
+Context
+→ createContext, Provider, useContext
+
+2단계 - 새로 알아야 할 것
+이벤트 에미터 패턴
+ts// React 밖에서 React 안으로 신호를 보내는 방법
+// 옵저버 패턴이라고도 함
+
+class EventEmitter {
+private listeners = new Map<string, Function>()
+
+// 구독
+on(event: string, callback: Function) {
+this.listeners.set(event, callback)
+}
+
+// 발행
+emit(event: string, payload?: any) {
+this.listeners.get(event)?.(payload)
+}
+}
+
+```
+
+```
+
+overlay.open() 호출
+↓ emit('OPEN', ...)
+OverlayProvider가 on('OPEN')으로 수신
+↓ dispatch({ type: 'OPEN' })
+useReducer가 상태 업데이트
+↓
+모달 렌더링
+useReducer
+tstype Action =
+| { type: 'OPEN'; id: string; component: Function }
+| { type: 'CLOSE'; id: string }
+| { type: 'UNMOUNT'; id: string }
+
+function reducer(state, action) {
+switch (action.type) {
+case 'OPEN': // 목록에 추가
+case 'CLOSE': // isOpen = false
+case 'UNMOUNT': // 목록에서 제거
+}
+}
+crypto.randomUUID()
+ts// overlay마다 고유한 id를 만드는 방법
+const id = crypto.randomUUID()
+// → "550e8400-e29b-41d4-a716-446655440000"
+
+```
+
+---
+
+### 3단계 - 핵심 연결 고리
+```
+
+React 밖 React 안
+
+---
+
+overlay.open()
+→ emitter.emit('OPEN')
+→ OverlayProvider가 수신
+→ dispatch({ type: 'OPEN' })
+→ state.overlays에 추가
+→ 렌더링
+
+```
+
+이 흐름을 이해하는 게 핵심이에요.
+
+---
+
+## 추천 공부 순서
+```
+
+1. useReducer 먼저 이해
+   → 간단한 counter를 useReducer로 만들어보기
+
+2. 이벤트 에미터 개념 이해
+   → 위 코드 직접 콘솔에서 돌려보기
+
+3. 둘을 연결하는 OverlayProvider 이해
+   → useEffect 안에서 emitter.on()으로 구독
+
+4. 실제 코드 작성
+
+useReducer가 익숙해요? 거기서 막히면 거기부터 같이 볼게요.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,12 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
   ]),
   prettier,
-  ...storybook.configs["flat/recommended"]
+  ...storybook.configs["flat/recommended"],
+  {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Input } from "../ui/input/Input";
+import { Input } from "@/shared/ui/input/Input";
 import { supabase } from "@/shared/api/supabase";
 import { Avatar } from "@/shared/ui/Avatar";
 import { User } from "@supabase/supabase-js";
@@ -7,6 +7,8 @@ import { useRouter } from "next/router";
 import storage from "@/shared/lib/storage";
 import { SearchIcon, PlusIcon, LogOutIcon } from "@/shared/ui/icons";
 import Link from "next/link";
+import { overlay } from "@/shared/lib/overlay/overlay";
+import { AddBookmarkOverlay } from "@/features/add-bookmark/ui/AddBookmarkOverlay";
 
 export const Header = () => {
   const router = useRouter();
@@ -74,6 +76,11 @@ export const Header = () => {
         <div className="flex items-center gap-4">
           <button
             type="button"
+            onClick={() =>
+              overlay.open(({ isOpen, close }) => (
+                <AddBookmarkOverlay isOpen={isOpen} onClose={close} />
+              ))
+            }
             className="bg-brand-primary hover:bg-brand-primary-hover focus:ring-brand-primary/20 flex cursor-pointer items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all focus:ring-4 focus:outline-none active:scale-95"
           >
             <PlusIcon />

--- a/src/docs/decisions/007-미니overlay-kit study.md
+++ b/src/docs/decisions/007-미니overlay-kit study.md
@@ -1,0 +1,367 @@
+# 🎭 overlay-kit 미니 버전 구현 학습
+
+> toss/overlay-kit 소스 분석 후 미니 버전 직접 구현  
+> 선언적 오버레이 관리 패턴 학습 목적
+
+---
+
+## 왜 이걸 공부했나
+
+기존 모달 구현 방식의 문제를 발견했다. `isOpen` 상태 선언, 열기 로직, 모달 JSX 배치가 컴포넌트 전체에 흩어져 있어 관련 코드를 한눈에 파악하기 어려웠다. 토스의 overlay-kit이 이 문제를 어떻게 해결했는지 분석하고, 미니 버전을 직접 구현해보기로 했다.
+
+---
+
+## 1. 기존 방식 vs overlay-kit 방식
+
+### 기존 방식 (명령형)
+
+```tsx
+function Page() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [targetId, setTargetId] = useState(null);
+
+  return (
+    <>
+      {items.map((item) => (
+        <button
+          onClick={() => {
+            setTargetId(item.id); // 어떤 아이템인지 따로 저장
+            setIsOpen(true); // 열기
+          }}
+        >
+          삭제
+        </button>
+      ))}
+
+      {/* 모달을 JSX 어딘가에 배치해야 함 */}
+      {isOpen && <DeleteModal id={targetId} onClose={() => setIsOpen(false)} />}
+    </>
+  );
+}
+```
+
+**문제점**
+
+```
+isOpen 선언   → 컴포넌트 상단
+열기 로직     → 중간 어딘가
+모달 배치     → 컴포넌트 하단
+→ 관련 코드가 파편화됨
+→ 아이템마다 다른 id를 넘기려면 state가 추가로 필요
+```
+
+### overlay-kit 방식 (선언형)
+
+```tsx
+function Page() {
+  return (
+    <>
+      {items.map((item) => (
+        <button
+          onClick={() => {
+            overlay.open(({ isOpen, close }) => (
+              <DeleteModal
+                id={item.id} // 클로저로 바로 캡처
+                open={isOpen}
+                onClose={close}
+              />
+            ));
+          }}
+        >
+          삭제
+        </button>
+      ))}
+      {/* 모달 JSX 배치 없음 */}
+    </>
+  );
+}
+```
+
+**개선점**
+
+```
+버튼과 모달이 같은 위치에 있음
+→ 코드 흐름이 한눈에 보임
+→ item.id를 클로저로 캡처해서 별도 state 불필요
+```
+
+---
+
+## 2. 내부 구조 (알아야 할 핵심 개념)
+
+### 전체 흐름
+
+```
+overlay.open() 호출 (React 외부)
+      ↓
+이벤트 에미터로 이벤트 발행
+      ↓
+OverlayProvider가 이벤트 수신
+      ↓
+useReducer로 overlay 목록에 추가
+      ↓
+Context를 통해 목록 렌더링
+```
+
+### 핵심 개념 1 - 이벤트 에미터 패턴
+
+`overlay.open()`이 React 컴포넌트 밖에서 호출될 수 있는 원리다.
+
+```ts
+// overlay.event.ts
+class OverlayEventEmitter {
+  private listeners: Map<string, Function> = new Map();
+
+  on(event: string, callback: Function) {
+    this.listeners.set(event, callback);
+  }
+
+  emit(event: string, payload: any) {
+    this.listeners.get(event)?.(payload);
+  }
+}
+
+const emitter = new OverlayEventEmitter();
+
+// overlay.open()은 그냥 이벤트를 발행하는 것
+export const overlay = {
+  open: (component) => {
+    const id = crypto.randomUUID();
+    emitter.emit("OPEN", { id, component });
+  },
+  close: (id) => emitter.emit("CLOSE", { id }),
+  unmount: (id) => emitter.emit("UNMOUNT", { id }),
+};
+```
+
+### 핵심 개념 2 - useReducer로 목록 관리
+
+```ts
+// overlay 목록 상태
+type OverlayState = {
+  overlays: Array<{
+    id: string;
+    isOpen: boolean;
+    component: (props: OverlayProps) => ReactNode;
+  }>;
+};
+
+type OverlayAction =
+  | { type: "OPEN"; id: string; component: Function }
+  | { type: "CLOSE"; id: string }
+  | { type: "UNMOUNT"; id: string };
+
+function overlayReducer(state: OverlayState, action: OverlayAction) {
+  switch (action.type) {
+    case "OPEN":
+      return {
+        overlays: [
+          ...state.overlays,
+          {
+            id: action.id,
+            isOpen: true,
+            component: action.component,
+          },
+        ],
+      };
+    case "CLOSE":
+      return {
+        overlays: state.overlays.map((o) => (o.id === action.id ? { ...o, isOpen: false } : o)),
+      };
+    case "UNMOUNT":
+      return {
+        overlays: state.overlays.filter((o) => o.id !== action.id),
+      };
+  }
+}
+```
+
+### 핵심 개념 3 - close vs unmount 차이
+
+```
+close()
+  → isOpen = false
+  → 모달이 숨겨짐
+  → DOM에는 아직 존재
+  → 애니메이션 실행 가능
+
+unmount()
+  → overlay 목록에서 완전히 제거
+  → DOM에서 사라짐
+  → 애니메이션 끝난 후 호출하는 게 맞음
+```
+
+```tsx
+// 올바른 사용 패턴
+<Dialog
+  open={isOpen}
+  onClose={close} // 닫기 버튼 → close (애니메이션 시작)
+  onAnimationEnd={unmount} // 애니메이션 끝 → unmount (DOM 제거)
+/>
+```
+
+### 핵심 개념 4 - OverlayProvider
+
+```tsx
+// 앱 최상단에 딱 한 번 배치
+function OverlayProvider({ children }) {
+  const [state, dispatch] = useReducer(overlayReducer, { overlays: [] });
+
+  // 이벤트 에미터 구독
+  useEffect(() => {
+    emitter.on("OPEN", ({ id, component }) => dispatch({ type: "OPEN", id, component }));
+    emitter.on("CLOSE", ({ id }) => dispatch({ type: "CLOSE", id }));
+    emitter.on("UNMOUNT", ({ id }) => dispatch({ type: "UNMOUNT", id }));
+  }, []);
+
+  return (
+    <OverlayContext.Provider value={state}>
+      {children}
+      {/* 모든 overlay가 여기서 렌더링됨 */}
+      {state.overlays.map(({ id, isOpen, component }) =>
+        component({ isOpen, close: () => overlay.close(id), unmount: () => overlay.unmount(id) })
+      )}
+    </OverlayContext.Provider>
+  );
+}
+```
+
+---
+
+## 3. 파일 구조 (미니 버전)
+
+```
+shared/lib/overlay/
+  ├── overlay.context.tsx   ← Context 정의
+  ├── overlay.reducer.ts    ← useReducer 액션/리듀서
+  ├── overlay.event.ts      ← 이벤트 에미터 + overlay 객체
+  ├── OverlayProvider.tsx   ← Provider + 렌더링
+  └── index.ts              ← export
+```
+
+---
+
+## 4. 좋은 점
+
+**관련 코드 응집**
+
+```
+버튼 클릭 로직과 모달 정의가 같은 위치에 있어
+코드 흐름을 한눈에 파악할 수 있다
+```
+
+**클로저로 변수 캡처**
+
+```tsx
+// item.id를 별도 state에 저장할 필요 없음
+overlay.open(({ isOpen, close }) => <DeleteModal id={item.id} open={isOpen} onClose={close} />);
+```
+
+**Promise 지원**
+
+```tsx
+// 모달 결과값을 await로 받을 수 있음
+const confirmed = await overlay.openAsync(({ isOpen, close }) => (
+  <ConfirmDialog open={isOpen} onConfirm={() => close(true)} onCancel={() => close(false)} />
+));
+if (confirmed) deleteItem();
+```
+
+**모달 컴포넌트 재사용성**
+
+```
+특정 페이지 JSX에 종속되지 않음
+어디서든 overlay.open()으로 호출 가능
+```
+
+---
+
+## 5. 트레이드오프 (나쁜 점)
+
+**러닝커브**
+
+```
+이벤트 에미터 + Context + Reducer 조합
+내부 구조를 모르면 디버깅이 어렵다
+팀원 모두가 패턴을 이해해야 유지보수 가능
+```
+
+**React 외부 상태 관리**
+
+```
+overlay.open()이 React 밖에서 호출됨
+→ React DevTools로 추적하기 어려움
+→ 상태 흐름이 명시적이지 않음
+```
+
+**남용 가능성**
+
+```
+어디서든 overlay.open() 호출 가능
+→ 코드베이스가 커지면 어디서 모달을 열었는지 파악 어려움
+→ 팀 컨벤션 없으면 스파게티 코드가 될 수 있음
+```
+
+**테스트 복잡도**
+
+```tsx
+// 일반 컴포넌트 테스트보다 설정 복잡
+render(
+  <OverlayProvider>
+    {" "}
+    // wrapper 필수
+    <Component />
+  </OverlayProvider>
+);
+```
+
+**작은 프로젝트엔 오버엔지니어링**
+
+```
+useState 하나로 해결될 걸
+이벤트 에미터 + Reducer + Context로 만드는 건
+복잡도 대비 효용이 낮을 수 있음
+```
+
+---
+
+## 6. 언제 쓰면 좋은가
+
+```
+✅ 적합한 경우
+  - 모달 종류가 많고 여러 페이지에서 재사용
+  - 목록 아이템마다 다른 id/데이터를 모달에 넘겨야 할 때
+  - 모달 결과값을 Promise로 처리해야 할 때
+  - 팀 전체가 패턴을 이해하고 있을 때
+
+❌ 과한 경우
+  - 모달이 1~2개뿐인 작은 프로젝트
+  - 팀원들이 패턴에 익숙하지 않을 때
+  - useState로 충분히 해결 가능한 경우
+```
+
+---
+
+## 7. 나의 생각
+
+```
+"토스 overlay-kit의 내부 구조(이벤트 에미터, Context, Reducer 패턴)를
+분석하고 미니 버전을 직접 구현했습니다.
+
+기존 명령형 모달 관리(useState + 조건부 렌더링)의 문제점인
+관련 코드 파편화와 상태 추가 관리 문제를 파악하고,
+
+선언적 오버레이 관리 패턴을 도입하여
+버튼과 모달 로직을 같은 위치에서 관리할 수 있는 구조를 구현했습니다.
+
+트레이드오프(React 외부 상태 관리로 인한 DevTools 추적 어려움,
+팀 러닝커브)를 이해하고 적용 여부를 판단할 수 있습니다."
+```
+
+---
+
+## 8. 참고
+
+- [toss/overlay-kit GitHub](https://github.com/toss/overlay-kit)
+- [이벤트 에미터 패턴](https://refactoring.guru/design-patterns/observer)
+- [React useReducer 공식문서](https://react.dev/reference/react/useReducer)

--- a/src/features/add-bookmark/ui/AddBookmarkOverlay.tsx
+++ b/src/features/add-bookmark/ui/AddBookmarkOverlay.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from "react";
+import { Link2, FileText, X, Plus } from "lucide-react";
+import { Input } from "@/shared/ui/input/Input";
+
+interface AddBookmarkOverlayProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * @description 북마크 추가를 위한 모달 오버레이 컴포넌트입니다.
+ * URL과 메모를 입력받아 새로운 북마크를 생성합니다.
+ */
+export const AddBookmarkOverlay = ({ isOpen, onClose }: AddBookmarkOverlayProps) => {
+  const [url, setUrl] = useState("");
+  const [memo, setMemo] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClose = () => onClose();
+
+  // 저장 로직 (나중에 API 연동 예정)
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url) return;
+
+    setIsLoading(true);
+    // TODO: 북마크 저장 API 호출
+    console.log("Saving bookmark:", { url, memo });
+
+    // 임시 딜레이 후 닫기
+    setTimeout(() => {
+      setIsLoading(false);
+      handleClose();
+    }, 800);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
+      {/* Backdrop: 배경 클릭 시 닫기 */}
+      <div
+        className="animate-in fade-in absolute inset-0 bg-zinc-950/60 backdrop-blur-sm transition-opacity duration-300"
+        onClick={handleClose}
+      />
+
+      {/* Modal Container */}
+      <div className="animate-in zoom-in-95 fade-in relative w-full max-w-md overflow-hidden rounded-3xl bg-white p-6 shadow-2xl duration-300 dark:bg-zinc-900">
+        {/* Header */}
+        <div className="mb-6 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="bg-brand-primary/10 text-brand-primary flex h-10 w-10 items-center justify-center rounded-2xl">
+              <Plus size={22} strokeWidth={2.5} />
+            </div>
+            <div>
+              <h3 className="text-lg font-bold text-zinc-900 dark:text-zinc-100">새 북마크 추가</h3>
+              <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                나중에 기억할 URL을 저장하세요
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={handleClose}
+            className="rounded-xl p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        {/* Form Content */}
+        <form onSubmit={handleSave} className="space-y-4">
+          <Input
+            label="URL 주소"
+            placeholder="https://example.com"
+            icon={<Link2 size={18} />}
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            autoFocus
+            required
+            className="w-full"
+          />
+
+          <Input
+            label="메모 (선택)"
+            placeholder="이 북마크에 대한 짧은 메모..."
+            icon={<FileText size={18} />}
+            value={memo}
+            onChange={(e) => setMemo(e.target.value)}
+            className="w-full"
+          />
+
+          {/* Footer Actions */}
+          <div className="mt-8 flex gap-3">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="flex-1 rounded-2xl border-2 border-zinc-100 bg-white py-3 text-sm font-bold text-zinc-600 transition-all hover:bg-zinc-50 active:scale-[0.98] dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={!url || isLoading}
+              className="dark:bg-brand-primary dark:hover:bg-brand-primary/90 flex-[1.5] rounded-2xl bg-zinc-900 py-3 text-sm font-bold text-white transition-all hover:bg-zinc-800 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-900"
+            >
+              {isLoading ? "저장 중..." : "북마크 저장"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,11 @@
+import { OverlayProvider } from "@/shared/lib/overlay/OverlayProvider";
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <OverlayProvider>
+      <Component {...pageProps} />
+    </OverlayProvider>
+  );
 }

--- a/src/shared/lib/overlay/OverlayProvider.tsx
+++ b/src/shared/lib/overlay/OverlayProvider.tsx
@@ -1,0 +1,48 @@
+import { useReducer, useEffect } from "react";
+import { overlayEmitter } from "./overlay.emitter";
+import { overlayReducer, initialState } from "./overlay.reducer";
+import { overlay } from "./overlay";
+import type { OverlayAction } from "./overlay.types";
+
+export function OverlayProvider({ children }: { children: React.ReactNode }) {
+  const [state, dispatch] = useReducer(overlayReducer, initialState);
+
+  useEffect(() => {
+    // OverlayProvider가 마운트되면
+    // emitter 신호 구독 시작
+    overlayEmitter.on("OPEN", (payload: OverlayAction & { type: "OPEN" }) => {
+      dispatch({ type: "OPEN", id: payload.id, component: payload.component });
+    });
+
+    overlayEmitter.on("CLOSE", (payload: { id: string }) => {
+      dispatch({ type: "CLOSE", id: payload.id });
+    });
+
+    overlayEmitter.on("UNMOUNT", (payload: { id: string }) => {
+      dispatch({ type: "UNMOUNT", id: payload.id });
+    });
+
+    // OverlayProvider가 언마운트되면
+    // 구독 해제
+    return () => {
+      overlayEmitter.off("OPEN");
+      overlayEmitter.off("CLOSE");
+      overlayEmitter.off("UNMOUNT");
+    };
+  }, []);
+
+  return (
+    <>
+      {children}
+
+      {/* overlay 목록 렌더링 */}
+      {state.overlays.map((item) =>
+        item.component({
+          isOpen: item.isOpen,
+          close: () => overlay.close(item.id),
+          unmount: () => overlay.unmount(item.id),
+        })
+      )}
+    </>
+  );
+}

--- a/src/shared/lib/overlay/index.ts
+++ b/src/shared/lib/overlay/index.ts
@@ -1,0 +1,5 @@
+export { overlay } from "./overlay";
+export { OverlayProvider } from "./OverlayProvider";
+
+// 타입도 필요하면
+export type { OverlayProps, OverlayComponent } from "./overlay.types";

--- a/src/shared/lib/overlay/overlay.emitter.ts
+++ b/src/shared/lib/overlay/overlay.emitter.ts
@@ -1,0 +1,30 @@
+import type { OverlayComponent } from "./overlay.types";
+
+// 이벤트별 payload 타입 정의
+type OverlayEventMap = {
+  OPEN: { id: string; component: OverlayComponent };
+  CLOSE: { id: string };
+  UNMOUNT: { id: string };
+};
+
+type OverlayEventKey = keyof OverlayEventMap;
+
+type EmitterListener<T> = (payload: T) => void;
+
+class OverlayEventEmitter {
+  private listeners = new Map<OverlayEventKey, EmitterListener<any>>();
+
+  on<K extends OverlayEventKey>(event: K, callback: EmitterListener<OverlayEventMap[K]>) {
+    this.listeners.set(event, callback);
+  }
+
+  emit<K extends OverlayEventKey>(event: K, payload: OverlayEventMap[K]) {
+    this.listeners.get(event)?.(payload);
+  }
+
+  off(event: OverlayEventKey) {
+    this.listeners.delete(event);
+  }
+}
+
+export const overlayEmitter = new OverlayEventEmitter();

--- a/src/shared/lib/overlay/overlay.reducer.ts
+++ b/src/shared/lib/overlay/overlay.reducer.ts
@@ -1,0 +1,35 @@
+import type { OverlayState, OverlayAction } from "./overlay.types";
+
+export const initialState: OverlayState = {
+  overlays: [],
+};
+
+export function overlayReducer(state: OverlayState, action: OverlayAction): OverlayState {
+  switch (action.type) {
+    case "OPEN":
+      return {
+        ...state,
+        overlays: [...state.overlays, { id: action.id, isOpen: true, component: action.component }],
+      };
+
+    case "CLOSE":
+      return {
+        ...state,
+        overlays: state.overlays.map((item) => {
+          if (item.id == action.id) {
+            return {
+              ...item,
+              isOpen: false,
+            };
+          }
+          return item;
+        }),
+      };
+
+    case "UNMOUNT":
+      return {
+        ...state,
+        overlays: state.overlays.filter((item) => item.id !== action.id),
+      };
+  }
+}

--- a/src/shared/lib/overlay/overlay.ts
+++ b/src/shared/lib/overlay/overlay.ts
@@ -1,0 +1,19 @@
+import { overlayEmitter } from "./overlay.emitter";
+import type { OverlayComponent } from "./overlay.types";
+
+export const overlay = {
+  open: (component: OverlayComponent) => {
+    const id = crypto.randomUUID();
+
+    overlayEmitter.emit("OPEN", { id, component });
+    //             ↑신호이름   ↑OverlayProvider한테 보낼 데이터
+  },
+
+  close: (id: string) => {
+    overlayEmitter.emit("CLOSE", { id });
+  },
+
+  unmount: (id: string) => {
+    overlayEmitter.emit("UNMOUNT", { id });
+  },
+};

--- a/src/shared/lib/overlay/overlay.types.ts
+++ b/src/shared/lib/overlay/overlay.types.ts
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+
+// props 타입 먼저
+type OverlayProps = {
+  isOpen: boolean;
+  close: () => void;
+  unmount: () => void;
+};
+
+// component 타입 명시적으로
+type OverlayComponent = (props: OverlayProps) => ReactNode;
+
+// 적용
+type OverlayItem = {
+  id: string;
+  isOpen: boolean;
+  component: OverlayComponent;
+};
+
+type OverlayState = {
+  overlays: OverlayItem[];
+};
+
+type OverlayAction =
+  | { type: "OPEN"; id: string; component: OverlayComponent }
+  | { type: "CLOSE"; id: string }
+  | { type: "UNMOUNT"; id: string };
+
+export type { OverlayProps, OverlayComponent, OverlayItem, OverlayState, OverlayAction };


### PR DESCRIPTION
## 📝 개요 (Summary)
overlay-kit 미니 모달 구현

## 🚀 주요 변경 사항 (Key Changes)
overlay-kit 미니 모달 구현
북마크 저장하는 모달 구현

## 🧠 기술적 의사결정 (Technical Decisions)
toss/overlay-kit 패턴을 분석하여 미니 버전을 직접 구현했습니다.

기존 useState 방식 대신 이벤트 에미터 + useReducer + Context 패턴을 
조합하여 React 외부에서 선언적으로 모달을 관리할 수 있는 구조를 도입했습니다.

- overlay.open()을 어디서든 호출 가능하도록 이벤트 에미터 패턴 적용
- 모달 컴포넌트가 overlay 시스템에 의존하지 않도록 의존성 분리
  (컴포넌트는 isOpen, onClose props만 받음)
- 향후 Toast, Drawer 등 다른 오버레이도 동일한 시스템으로 확장 가능

## ✅ 체크리스트 (Self-Checklist)
- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가?
- [ ] 불필요한 콘솔 로그나 주석을 제거했는가?
- [ ] `npm run lint` 및 `npm run format`을 실행하여 오류가 없는가?
- [ ] 새로운 기능에 대한 테스트 코드를 작성했는가? (권장)
