### PR TITLE
fix(bookmark): BookmarkDetailPanel isOpen 판단 기준을 bookmark prop으로 수정

### DIFF
--- a/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
@@ -61,7 +61,7 @@ export const BookmarkDetailPanel = ({ bookmark, onSave, onTagClick }: BookmarkDe
     setTagInput("");
   };
 
-  const isOpen = !!selectedBookmarkId;
+  const isOpen = !!bookmark;
 
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION
## 📝 개요 (Summary)
PR #21 머지 후 발생한 `selectedBookmarkId is not defined` 런타임 에러를 수정합니다.

## 🚀 주요 변경 사항 (Key Changes)
- [x] `BookmarkDetailPanel`의 `isOpen` 판단 기준을 `selectedBookmarkId` → `bookmark` prop으로 변경

## 🧠 기술적 의사결정 (Technical Decisions)
- TanStack Query 마이그레이션으로 `useBookmarkStore`에서 `bookmarks`가 제거됨
- `selectedBookmarkId`가 더 이상 스토어에 없으므로 `!!bookmark` prop으로 열림 여부 판단

## 🔗 관련 이슈 (Related Issues)
- 관련 PR: #21

## ✅ 체크리스트 (Self-Checklist)
- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가?
- [x] 불필요한 콘솔 로그나 주석을 제거했는가?
- [x] `pnpm build` 통과 확인
- [x] 새로운 기능에 대한 테스트 코드를 작성했는가? (권장) — 단순 버그 수정으로 생략