### PR TITLE
fix(overlay): OverlayProvider map 렌더링에 Fragment key 추가

### DIFF
--- a/apps/web/src/shared/lib/overlay/OverlayProvider.tsx
+++ b/apps/web/src/shared/lib/overlay/OverlayProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer, useEffect } from "react";
+import { Fragment, useReducer, useEffect } from "react";
 import { overlayEmitter } from "./overlay.emitter";
 import { overlayReducer, initialState } from "./overlay.reducer";
 import { overlay } from "./overlay";
@@ -38,13 +38,15 @@ export function OverlayProvider({ children }: { children: React.ReactNode }) {
       {children}
 
       {/* overlay 목록 렌더링 */}
-      {state.overlays.map((item) =>
-        item.component({
-          isOpen: item.isOpen,
-          close: () => overlay.close(item.id),
-          unmount: () => overlay.unmount(item.id),
-        })
-      )}
+      {state.overlays.map((item) => (
+        <Fragment key={item.id}>
+          {item.component({
+            isOpen: item.isOpen,
+            close: () => overlay.close(item.id),
+            unmount: () => overlay.unmount(item.id),
+          })}
+        </Fragment>
+      ))}
     </>
   );
 }


### PR DESCRIPTION
## 📝 개요 (Summary)
`OverlayProvider`의 overlay 목록 렌더링 시 발생하는 `Each child in a list should have a unique key prop` 경고를 수정합니다.

## 🚀 주요 변경 사항 (Key Changes)
- [x] `state.overlays.map` 반환값을 `<Fragment key={item.id}>` 로 감싸 key prop 추가
- [x] `React` 전체 import → `{ Fragment }` named import로 변경

## 🧠 기술적 의사결정 (Technical Decisions)
- `<div>` 대신 `Fragment`를 사용해 불필요한 DOM 노드 추가 없이 key 부여
- `React` 전체 import 대신 필요한 것만 named import

## ✅ 체크리스트 (Self-Checklist)
- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가?
- [x] 불필요한 콘솔 로그나 주석을 제거했는가?
- [x] `pnpm build` 통과 확인