### PR TITLE
feat: 익스텐션 로그인시 웹앱가기도 로그인 되도록 구현

### DIFF
--- a/apps/extension/entrypoints/popup/App.tsx
+++ b/apps/extension/entrypoints/popup/App.tsx
@@ -259,7 +259,20 @@ function SaveView({ user, onLogout }: { user: User; onLogout: () => void }) {
 
       <button
         style={styles.secondaryBtn}
-        onClick={() => chrome.tabs.create({ url: `${WEB_URL}/` })}
+        onClick={async () => {
+          const {
+            data: { session },
+          } = await supabase.auth.getSession();
+          if (session) {
+            const params = new URLSearchParams({
+              access_token: session.access_token,
+              refresh_token: session.refresh_token ?? "",
+            });
+            chrome.tabs.create({ url: `${WEB_URL}/auth/web-redirect#${params.toString()}` });
+          } else {
+            chrome.tabs.create({ url: `${WEB_URL}/` });
+          }
+        }}
       >
         앱에서 보기 →
       </button>

--- a/apps/web/src/app/auth/web-redirect/page.tsx
+++ b/apps/web/src/app/auth/web-redirect/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/shared/api/supabase/client";
+
+// 익스텐션 → 웹앱 세션 연결
+// URL hash에서 access_token, refresh_token을 읽어 쿠키 세션 생성 후 메인으로 이동
+export default function WebRedirectPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const hash = window.location.hash.slice(1);
+    const params = new URLSearchParams(hash);
+    const accessToken = params.get("access_token");
+    const refreshToken = params.get("refresh_token");
+
+    if (!accessToken || !refreshToken) {
+      router.replace("/login");
+      return;
+    }
+
+    // 토큰 읽은 즉시 URL에서 제거 (브라우저 히스토리에 토큰 남지 않도록)
+    window.history.replaceState(null, "", window.location.pathname);
+
+    supabase.auth
+      .setSession({ access_token: accessToken, refresh_token: refreshToken })
+      .then(({ error }) => {
+        if (error) {
+          router.replace("/login");
+        } else {
+          router.replace("/");
+        }
+      });
+  }, [router]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="flex flex-col items-center gap-3">
+        <svg className="h-8 w-8 animate-spin text-zinc-400" viewBox="0 0 24 24" fill="none">
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        <p className="text-sm text-zinc-500">로그인 중...</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -80,6 +80,7 @@ export async function middleware(request: NextRequest) {
     !isLoginPage &&
     !pathname.startsWith("/auth/callback") &&
     !pathname.startsWith("/auth/extension-token") &&
+    !pathname.startsWith("/auth/web-redirect") &&
     !pathname.startsWith("/api") &&
     !pathname.startsWith("/_next")
   ) {

--- a/docs/decisions/017-extension-api-architecture.md
+++ b/docs/decisions/017-extension-api-architecture.md
@@ -1,0 +1,117 @@
+# 크롬 익스텐션 API 아키텍처 — 왜 웹앱 안에 API를 만들었나
+
+## 구조
+
+```
+익스텐션 팝업에서 "저장" 클릭
+        ↓
+apps/extension → fetch POST → https://smartmark.wooyou.co.kr/api/extension/save-bookmark
+        ↓
+apps/web API Route (서버)
+  1. Bearer 토큰으로 유저 확인
+  2. Supabase에 북마크 insert
+  3. 크롤링 + AI 분석 백그라운드 실행
+```
+
+## 왜 익스텐션에서 Supabase에 직접 저장 안 하냐
+
+기술적으로는 가능하지만 두 가지 문제가 있다.
+
+| 문제                 | 이유                                                                     |
+| -------------------- | ------------------------------------------------------------------------ |
+| 크롤링/AI 파이프라인 | 서버에서만 실행 가능 (Node.js 환경 필요)                                 |
+| 보안                 | Gemini API Key 같은 시크릿 키를 익스텐션 코드에 넣으면 누구나 볼 수 있음 |
+
+익스텐션은 번들이 공개되기 때문에 코드 안에 시크릿 키를 넣으면 안 된다.
+
+---
+
+## 인증 방식 — Bearer 토큰
+
+웹앱은 쿠키 기반 세션을 쓰는데, 익스텐션은 쿠키를 공유할 수 없다.
+그래서 익스텐션은 Supabase `access_token`을 `Authorization: Bearer` 헤더로 전송한다.
+
+```typescript
+// 익스텐션 (apps/extension)
+const {
+  data: { session },
+} = await supabase.auth.getSession();
+
+fetch(`${WEB_URL}/api/extension/save-bookmark`, {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session.access_token}`, // ← 쿠키 대신 Bearer
+  },
+  body: JSON.stringify({ url: currentUrl }),
+});
+```
+
+```typescript
+// 웹앱 API Route (apps/web)
+async function getUserFromBearer(authHeader: string | null) {
+  const token = authHeader.slice(7); // "Bearer " 제거
+
+  // 1단계: 토큰 유효성 검증
+  const anonClient = createClient(url, anonKey);
+  const {
+    data: { user },
+  } = await anonClient.auth.getUser(token);
+
+  // 2단계: RLS가 유저 JWT 인식하도록 Authorization 헤더 주입
+  const supabase = createClient(url, anonKey, {
+    global: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  });
+
+  return { user, supabase };
+}
+```
+
+---
+
+## RLS 500 에러 트러블슈팅
+
+### 에러 상황
+
+익스텐션에서 저장하면 500 "저장 실패" 반환.
+
+### 원인
+
+`createClient(url, anonKey)` 로 만든 클라이언트는 **익명 상태**다.
+`auth.getUser(token)` 으로 유저를 확인해도, 그 클라이언트 자체는 여전히 anon key로 요청을 보낸다.
+Supabase RLS는 요청의 JWT를 보고 판단하는데, anon key 요청이라 "인증 안 된 유저"로 처리 → insert 차단 → 500.
+
+```
+❌ 잘못된 흐름
+anonClient.auth.getUser(token) → user 확인 OK
+anonClient.from("bookmarks").insert(...) → RLS: "너 anon이잖아" → 차단
+```
+
+### 해결
+
+DB 작업용 클라이언트를 별도로 만들 때 `Authorization` 헤더에 유저 JWT를 직접 주입한다.
+
+```typescript
+// ✅ 올바른 흐름
+const supabase = createClient(url, anonKey, {
+  global: {
+    headers: { Authorization: `Bearer ${token}` },  // ← JWT 주입
+  },
+});
+
+supabase.from("bookmarks").insert(...) → RLS: "JWT 확인, 통과" → insert 성공
+```
+
+### 핵심 개념
+
+Supabase RLS는 **클라이언트 키가 아니라 요청 헤더의 JWT**를 보고 판단한다.
+anon key로 클라이언트를 만들어도, 헤더에 유저 JWT가 있으면 RLS는 그 유저로 인식한다.
+
+---
+
+## 관련 파일
+
+- `apps/web/src/app/api/extension/save-bookmark/route.ts` — 웹앱 API Route
+- `apps/extension/entrypoints/popup/App.tsx` — 익스텐션에서 fetch 호출부 (`SaveView` 컴포넌트)


### PR DESCRIPTION
## 📝 개요 (Summary)
익스텐션 로그인시 웹앱가기도 로그인 되도록 구현

## 🚀 주요 변경 사항 (Key Changes)
- [x] 익스텐션 로그인시 웹앱가기도 로그인 되도록 구현 

## 🧠 기술적 의사결정 (Technical Decisions) 
브라우ㅋ저 쿠키에 세션 저장을 하고 미들웨어가 쿠키확인을 하고 로그인 상태를 인식 하도록 만들었다. 
지금은 웹에서 로그인 상태를 인식을 하지 못하고 있다. 


## ✅ 체크리스트 (Self-Checklist)
- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가?
- [x] 불필요한 콘솔 로그나 주석을 제거했는가?
- [x] `npm run lint` 및 `npm run format`을 실행하여 오류가 없는가?
- [ ] 새로운 기능에 대한 테스트 코드를 작성했는가? (권장)
