### PR TITLE
refactor(bookmark): 에러 처리 개선 - 타입 안전한 에러 클래스 도입

### DIFF
--- a/apps/web/src/entities/bookmark/api/local.repository.ts
+++ b/apps/web/src/entities/bookmark/api/local.repository.ts
@@ -4,6 +4,7 @@ import type { Bookmark } from "../model/types";
 import { toBookmark } from "../lib/bookmark.mapper";
 import { BookmarkRepository, UpdateBookmarkData } from "./bookmark.repository";
 import getGuestId from "@/shared/lib/guest";
+import { BookmarkError, BookmarkErrorCode } from "../model/bookmark.error";
 
 const GUEST_KEY = "GUEST_BOOKMARK";
 
@@ -24,7 +25,10 @@ export class LocalRepository implements BookmarkRepository {
     const currentRows = this.getRows();
 
     if (currentRows.length >= 5) {
-      throw new Error("무료 체험 한도(5개)를 초과했습니다. 로그인이 필요합니다.");
+      throw new BookmarkError(
+        BookmarkErrorCode.GUEST_LIMIT_EXCEEDED,
+        "무료 체험 한도(5개)를 초과했습니다. 로그인이 필요합니다."
+      );
     }
 
     const newRow: BookmarkRow = {
@@ -99,7 +103,10 @@ export class LocalRepository implements BookmarkRepository {
     const index = rows.findIndex((item) => item.id === id);
 
     if (index === -1) {
-      throw new Error(`ID가 ${id}인 북마크를 찾을 수 없습니다.`);
+      throw new BookmarkError(
+        BookmarkErrorCode.BOOKMARK_NOT_FOUND,
+        `ID가 ${id}인 북마크를 찾을 수 없습니다.`
+      );
     }
 
     const updatedRows = rows.map((row) =>

--- a/apps/web/src/entities/bookmark/api/supabase.repository.ts
+++ b/apps/web/src/entities/bookmark/api/supabase.repository.ts
@@ -3,6 +3,7 @@ import type { BookmarkRow, BookmarkFilter, CreateBookmarkRequest } from "./bookm
 import type { Bookmark } from "../model/types";
 import { toBookmark } from "../lib/bookmark.mapper";
 import { BookmarkRepository, UpdateBookmarkData } from "./bookmark.repository";
+import { BookmarkError, BookmarkErrorCode } from "../model/bookmark.error";
 
 type SupabaseDbRow = {
   id: string;
@@ -45,7 +46,13 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
       .select()
       .single();
 
-    if (error) throw new Error(`북마크 저장 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.DB_INSERT_FAILED,
+        `북마크 저장 실패: ${error.message}`,
+        error
+      );
+    }
 
     return toBookmark(this.toRow(data, []));
   }
@@ -66,7 +73,13 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
 
     const { data, error } = await query.order("created_at", { ascending: false });
 
-    if (error) throw new Error(`목록 조회 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.DB_QUERY_FAILED,
+        `목록 조회 실패: ${error.message}`,
+        error
+      );
+    }
 
     const bookmarks = (data as unknown as SupabaseDbRow[]).map((row) =>
       toBookmark(this.toRow(row, this.extractTags(row)))
@@ -92,12 +105,24 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
 
   async delete(id: string): Promise<void> {
     const { error } = await supabase.from("bookmarks").delete().eq("id", id);
-    if (error) throw new Error(`삭제 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.DB_DELETE_FAILED,
+        `삭제 실패: ${error.message}`,
+        error
+      );
+    }
   }
 
   async removeAll(): Promise<void> {
     const { error } = await supabase.from("bookmarks").delete().eq("user_id", this.userId);
-    if (error) throw new Error(`전체 삭제 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.DB_DELETE_FAILED,
+        `전체 삭제 실패: ${error.message}`,
+        error
+      );
+    }
   }
 
   async count(): Promise<number> {
@@ -120,7 +145,13 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
     if (data.status !== undefined) updateFields.status = data.status;
 
     const { error } = await supabase.from("bookmarks").update(updateFields).eq("id", id);
-    if (error) throw new Error(`업데이트 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.DB_UPDATE_FAILED,
+        `업데이트 실패: ${error.message}`,
+        error
+      );
+    }
 
     if (data.tags !== undefined) {
       await this.replaceTags(id, data.tags);
@@ -136,7 +167,13 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
       .delete()
       .eq("bookmark_id", bookmarkId);
 
-    if (deleteError) throw new Error(`태그 삭제 실패: ${deleteError.message}`);
+    if (deleteError) {
+      throw new BookmarkError(
+        BookmarkErrorCode.TAG_DELETE_FAILED,
+        `태그 삭제 실패: ${deleteError.message}`,
+        deleteError
+      );
+    }
 
     if (tagNames.length > 0) {
       await this.insertTags(bookmarkId, tagNames);
@@ -151,7 +188,13 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
       .from("embeddings")
       .upsert({ bookmark_id: bookmarkId, embedding });
 
-    if (error) throw new Error(`임베딩 저장 실패: ${error.message}`);
+    if (error) {
+      throw new BookmarkError(
+        BookmarkErrorCode.EMBEDDING_SAVE_FAILED,
+        `임베딩 저장 실패: ${error.message}`,
+        error
+      );
+    }
   }
 
   /**

--- a/apps/web/src/entities/bookmark/lib/bookmark.mapper.test.ts
+++ b/apps/web/src/entities/bookmark/lib/bookmark.mapper.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { toBookmark } from "./bookmark.mapper";
+import type { BookmarkRow } from "../api/bookmark.types.db";
+
+describe("BookmarkMapper", () => {
+  describe("toBookmark", () => {
+    it("should convert BookmarkRow to Bookmark correctly", () => {
+      const row: BookmarkRow = {
+        id: "bookmark-1",
+        url: "https://example.com",
+        title: "Example Page",
+        summary: "This is a summary",
+        content: "Full content here",
+        userMemo: "My notes",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        aiStatus: "completed",
+        tags: ["react", "typescript"],
+        status: "unread",
+        createdAt: "2024-03-08T00:00:00Z",
+        userId: "user-123",
+        updatedAt: "2024-03-08T10:00:00Z",
+      };
+
+      const result = toBookmark(row);
+
+      expect(result).toEqual({
+        id: "bookmark-1",
+        url: "https://example.com",
+        title: "Example Page",
+        summary: "This is a summary",
+        thumbnailUrl: "https://example.com/thumb.jpg",
+        aiStatus: "completed",
+        tags: ["react", "typescript"],
+        status: "unread",
+        userId: "user-123",
+        createdAt: "2024-03-08T00:00:00Z",
+        updatedAt: "2024-03-08T10:00:00Z",
+      });
+    });
+
+    it("should handle missing userId by converting to empty string", () => {
+      const row: BookmarkRow = {
+        id: "bookmark-1",
+        url: "https://example.com",
+        title: "Example",
+        summary: "",
+        aiStatus: "crawling",
+        tags: [],
+        status: "unread",
+        createdAt: "2024-03-08T00:00:00Z",
+        updatedAt: "2024-03-08T00:00:00Z",
+        guestId: "guest-123",
+      };
+
+      const result = toBookmark(row);
+
+      expect(result.userId).toBe("");
+    });
+
+    it("should exclude optional fields not in Bookmark interface", () => {
+      const row: BookmarkRow = {
+        id: "bookmark-1",
+        url: "https://example.com",
+        title: "Example",
+        summary: "",
+        content: "Full content",
+        userMemo: "Notes",
+        aiStatus: "crawling",
+        tags: [],
+        status: "unread",
+        createdAt: "2024-03-08T00:00:00Z",
+        updatedAt: "2024-03-08T00:00:00Z",
+        guestId: "guest-123",
+      };
+
+      const result = toBookmark(row);
+
+      expect(result).not.toHaveProperty("content");
+      expect(result).not.toHaveProperty("userMemo");
+      expect(result).not.toHaveProperty("guestId");
+    });
+
+    it("should handle all aiStatus types", () => {
+      const statuses: Array<"crawling" | "processing" | "completed" | "failed"> = [
+        "crawling",
+        "processing",
+        "completed",
+        "failed",
+      ];
+
+      statuses.forEach((status) => {
+        const row: BookmarkRow = {
+          id: "bookmark-1",
+          url: "https://example.com",
+          title: "Example",
+          summary: "",
+          aiStatus: status,
+          tags: [],
+          status: "unread",
+          createdAt: "2024-03-08T00:00:00Z",
+          updatedAt: "2024-03-08T00:00:00Z",
+        };
+
+        const result = toBookmark(row);
+        expect(result.aiStatus).toBe(status);
+      });
+    });
+
+    it("should preserve all tags when converting", () => {
+      const tags = ["react", "typescript", "testing", "next.js"];
+      const row: BookmarkRow = {
+        id: "bookmark-1",
+        url: "https://example.com",
+        title: "Example",
+        summary: "",
+        aiStatus: "completed",
+        tags,
+        status: "unread",
+        createdAt: "2024-03-08T00:00:00Z",
+        updatedAt: "2024-03-08T00:00:00Z",
+      };
+
+      const result = toBookmark(row);
+
+      expect(result.tags).toEqual(tags);
+      expect(result.tags.length).toBe(4);
+    });
+  });
+});

--- a/apps/web/src/entities/bookmark/model/bookmark.error.ts
+++ b/apps/web/src/entities/bookmark/model/bookmark.error.ts
@@ -1,0 +1,62 @@
+/**
+ * @description 북마크 관련 에러 코드
+ */
+export enum BookmarkErrorCode {
+  // 게스트 관련
+  GUEST_LIMIT_EXCEEDED = "GUEST_LIMIT_EXCEEDED",
+
+  // 조회 관련
+  BOOKMARK_NOT_FOUND = "BOOKMARK_NOT_FOUND",
+
+  // DB 작업 관련
+  DB_INSERT_FAILED = "DB_INSERT_FAILED",
+  DB_QUERY_FAILED = "DB_QUERY_FAILED",
+  DB_UPDATE_FAILED = "DB_UPDATE_FAILED",
+  DB_DELETE_FAILED = "DB_DELETE_FAILED",
+
+  // 태그 관련
+  TAG_DELETE_FAILED = "TAG_DELETE_FAILED",
+  TAG_INSERT_FAILED = "TAG_INSERT_FAILED",
+
+  // 임베딩 관련
+  EMBEDDING_SAVE_FAILED = "EMBEDDING_SAVE_FAILED",
+
+  // 기타
+  INVALID_URL = "INVALID_URL",
+  UNKNOWN_ERROR = "UNKNOWN_ERROR",
+}
+
+/**
+ * @description 북마크 관련 커스텀 에러
+ */
+export class BookmarkError extends Error {
+  constructor(
+    public readonly code: BookmarkErrorCode,
+    message: string,
+    public readonly originalError?: unknown
+  ) {
+    super(message);
+    this.name = "BookmarkError";
+
+    // Error 프로토타입 체인 복구 (instanceof 동작 보장)
+    Object.setPrototypeOf(this, BookmarkError.prototype);
+  }
+}
+
+/**
+ * @description 에러 메시지 매핑 (사용자에게 표시할 메시지)
+ */
+export const BookmarkErrorMessages: Record<BookmarkErrorCode, string> = {
+  [BookmarkErrorCode.GUEST_LIMIT_EXCEEDED]:
+    "무료 체험 한도(5개)를 초과했습니다. 로그인이 필요합니다.",
+  [BookmarkErrorCode.BOOKMARK_NOT_FOUND]: "북마크를 찾을 수 없습니다.",
+  [BookmarkErrorCode.DB_INSERT_FAILED]: "북마크 저장에 실패했습니다.",
+  [BookmarkErrorCode.DB_QUERY_FAILED]: "북마크 조회에 실패했습니다.",
+  [BookmarkErrorCode.DB_UPDATE_FAILED]: "북마크 업데이트에 실패했습니다.",
+  [BookmarkErrorCode.DB_DELETE_FAILED]: "북마크 삭제에 실패했습니다.",
+  [BookmarkErrorCode.TAG_DELETE_FAILED]: "태그 삭제에 실패했습니다.",
+  [BookmarkErrorCode.TAG_INSERT_FAILED]: "태그 추가에 실패했습니다.",
+  [BookmarkErrorCode.EMBEDDING_SAVE_FAILED]: "임베딩 저장에 실패했습니다.",
+  [BookmarkErrorCode.INVALID_URL]: "유효하지 않은 URL입니다.",
+  [BookmarkErrorCode.UNKNOWN_ERROR]: "알 수 없는 오류가 발생했습니다.",
+};


### PR DESCRIPTION
## 📝 무엇을 만들었나요

타입 안전한 에러 처리를 위해 BookmarkError 클래스와 BookmarkErrorCode enum을 도입했습니다.

## 🚀 주요 변경 사항

- BookmarkError 클래스 및 BookmarkErrorCode enum 정의
- 일반 Error 대신 구조화된 에러 사용으로 타입 안전성 강화
- GUEST_LIMIT_EXCEEDED, BOOKMARK_NOT_FOUND 에러 코드 추가
- LocalRepository와 SupabaseBookmarkRepository에 타입 안전한 에러 처리 적용
- bookmark.mapper 테스트 파일 추가 (129 라인)
- 기존 useBookmarkStore.test.ts 제거

## 🔗 관련 이슈

없음

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음
- [x] 린트 통과
- [x] 불필요한 console.log 제거