### PR TITLE
fix: allow crawl failed ai status

### DIFF
--- a/supabase/migrations/005_add_crawl_failed_ai_status.sql
+++ b/supabase/migrations/005_add_crawl_failed_ai_status.sql
@@ -1,0 +1,14 @@
+alter table bookmarks
+drop constraint if exists bookmarks_ai_status_check;
+
+alter table bookmarks
+add constraint bookmarks_ai_status_check
+check (
+  ai_status in (
+    'crawling',
+    'processing',
+    'completed',
+    'failed',
+    'crawl_failed'
+  )
+);


### PR DESCRIPTION
---
📝 개요 (Summary)

앱이 사용하는 crawl_failed AI 상태를 Supabase ai_status CHECK 제약에 추가해, 크롤링 실패 시 DB 저장이 거부되던 문제를 해결합니다.

🚀 주요 변경 사항 (Key Changes)

- [x] supabase/migrations/005_add_crawl_failed_ai_status.sql 추가 — bookmarks_ai_status_check 제약을 재생성하여 허용값에 crawl_failed 포함 (crawling, processing, completed, failed, crawl_failed)
- [x] 기존 제약을 drop constraint if exists로 안전하게 제거 후 재생성 (재실행 가능하도록 idempotent 처리)

🧠 기술적 의사결정 (Technical Decisions)

- 왜 필요했나: 앱 타입 AIStatus(types.ts)와 파이프라인(useBookmarkPipeline.ts)은 크롤링 단계 실패 시 aiStatus: "crawl_failed"로 기록하지만, DB의 CHECK 제약에는 이 값이 없어 updateBookmark 시 제약 위반으로 저장이 거부됐습니다. 코드와 DB 스키마 간 불일치를 스키마 쪽에서 맞췄습니다.
- failed와 crawl_failed를 분리한 이유: 크롤링 단계 실패(crawl_failed)와 AI 분석 단계 실패(failed)를 구분해, UI에서 서로 다른 안내/재시도 흐름을 줄 수 있도록 상태를 나눴습니다.
- 마이그레이션 방식: ALTER ... DROP CONSTRAINT IF EXISTS 후 재생성하는 방식으로 작성해, 이미 적용된 환경에서도 안전하게 재실행할 수 있게 했습니다.

🔗 관련 이슈 (Related Issues)

- Fixes #<!-- 해당 이슈 번호가 있으면 채워주세요 -->

✅ 체크리스트 (Self-Checklist)

- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가? — DB 마이그레이션 변경으로 FSD 레이어 영향 없음
- [x] 불필요한 콘솔 로그나 주석을 제거했는가?
- [ ] npm run lint 및 npm run format을 실
- [ ] 새로운 기능에 대한 테스트 코드를 작성했는가? (권장) — DB 제약 변경으로 별도 단위 테스트 없음 (앱 상태 

- Fixes #<!-- 해당 이슈 번호가 있으면 채워주세요 -->

✅ 체크리스트 (Self-Checklist)

- [x] 코드가 프로젝트의 FSD 아키텍처 및 스타일 가이드를 준수하는가? — DB 마이그레이션 변경으로 FSD 레이어 영향 없음
- [x] 불필요한 콘솔 로그나 주석을 제거했는가?
- [ ] npm run lint 및 npm run format을 실행하여 오류가 없는가? — SQL 마이그레이션만 변경되어 해당 없음
- [ ] 새로운 기능에 대한 테스트 코드를 작성했는가? (권장) — DB 제약 변경으로 별도 단위 테스트 없음 (앱 상태 매핑은 기존 bookmark.mapper.test.ts에서 커버)