### PR TITLE
feat: 데이터 로드 실패 에러 UI + 키보드/모바일 접근성

### DIFF
--- a/apps/web/src/app/(main)/bookmarks/BookmarksContent.tsx
+++ b/apps/web/src/app/(main)/bookmarks/BookmarksContent.tsx
@@ -16,6 +16,7 @@ import {
 import { useBookmarkStore } from "@/entities/bookmark/model/useBookmarkStore";
 import { supabase } from "@/shared/api/supabase/client";
 import storage from "@/shared/lib/storage";
+import { ErrorState } from "@/shared/ui/ErrorState";
 import type { Bookmark } from "@/entities/bookmark/model/types";
 import { X } from "lucide-react";
 
@@ -35,7 +36,7 @@ export function BookmarksContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { selectedBookmarkId, setSelectedBookmarkId } = useBookmarkStore();
-  const { data: bookmarks = [] } = useBookmarks();
+  const { data: bookmarks = [], isError, refetch } = useBookmarks();
   const { mutate: updateBookmark, mutateAsync: updateBookmarkAsync } = useUpdateBookmark();
   const { mutateAsync: deleteBookmarkAsync } = useDeleteBookmark();
 
@@ -214,25 +215,36 @@ export function BookmarksContent() {
           </div>
         )}
 
-        <p className="mb-6 text-sm text-zinc-500 dark:text-zinc-400">
-          {keywordFiltered.length}개의 북마크
-        </p>
-
-        <BookmarkList
-          bookmarks={keywordFiltered}
-          onBookmarkClick={handleBookmarkClick}
-          onTagClick={handleTagClick}
-        />
-
-        {showSemanticSection && (
-          <SemanticResultSection
-            exact={deduplicatedExact}
-            related={deduplicatedRelated}
-            isLoading={semanticLoading}
-            isGuest={isGuest}
-            onBookmarkClick={handleBookmarkClick}
-            onTagClick={handleTagClick}
+        {isError ? (
+          <ErrorState
+            title="북마크를 불러오지 못했어요"
+            description="네트워크 문제일 수 있어요. 다시 시도해 주세요."
+            onRetry={() => refetch()}
+            className="py-20"
           />
+        ) : (
+          <>
+            <p className="mb-6 text-sm text-zinc-500 dark:text-zinc-400">
+              {keywordFiltered.length}개의 북마크
+            </p>
+
+            <BookmarkList
+              bookmarks={keywordFiltered}
+              onBookmarkClick={handleBookmarkClick}
+              onTagClick={handleTagClick}
+            />
+
+            {showSemanticSection && (
+              <SemanticResultSection
+                exact={deduplicatedExact}
+                related={deduplicatedRelated}
+                isLoading={semanticLoading}
+                isGuest={isGuest}
+                onBookmarkClick={handleBookmarkClick}
+                onTagClick={handleTagClick}
+              />
+            )}
+          </>
         )}
       </main>
     </div>

--- a/apps/web/src/app/(main)/collections/CollectionsContent.tsx
+++ b/apps/web/src/app/(main)/collections/CollectionsContent.tsx
@@ -6,10 +6,11 @@ import { Plus, FolderOpen } from "lucide-react";
 import { CollectionCard } from "@/entities/collection/ui/CollectionCard";
 import { CreateCollectionModal } from "@/features/collection/ui/CreateCollectionModal";
 import { useCollections } from "@/features/collection/model/queries";
+import { ErrorState } from "@/shared/ui/ErrorState";
 
 export function CollectionsContent() {
   const router = useRouter();
-  const { data: collections = [], isLoading } = useCollections();
+  const { data: collections = [], isLoading, isError, refetch } = useCollections();
   const [showCreate, setShowCreate] = useState(false);
 
   return (
@@ -32,7 +33,14 @@ export function CollectionsContent() {
           </button>
         </div>
 
-        {isLoading ? (
+        {isError ? (
+          <ErrorState
+            title="컬렉션을 불러오지 못했어요"
+            description="네트워크 문제일 수 있어요. 다시 시도해 주세요."
+            onRetry={() => refetch()}
+            className="py-32"
+          />
+        ) : isLoading ? (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 6 }).map((_, i) => (
               <div

--- a/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
+++ b/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
@@ -15,6 +15,7 @@ import { useBookmarkStore } from "@/entities/bookmark/model/useBookmarkStore";
 import { BookmarkDetailPanel } from "@/entities/bookmark/ui/BookmarkDetailPanel";
 import { useUpdateBookmark } from "@/features/bookmark/model/queries";
 import { supabase } from "@/shared/api/supabase/client";
+import { ErrorState } from "@/shared/ui/ErrorState";
 import { useEffect } from "react";
 import type { Bookmark } from "@/entities/bookmark/model/types";
 
@@ -24,8 +25,18 @@ interface Props {
 
 export function CollectionDetailContent({ id }: Props) {
   const router = useRouter();
-  const { data: collection, isLoading: colLoading } = useCollection(id);
-  const { data: bookmarks = [], isLoading: bkLoading } = useCollectionBookmarks(id);
+  const {
+    data: collection,
+    isLoading: colLoading,
+    isError: colError,
+    refetch: refetchCol,
+  } = useCollection(id);
+  const {
+    data: bookmarks = [],
+    isLoading: bkLoading,
+    isError: bkError,
+    refetch: refetchBk,
+  } = useCollectionBookmarks(id);
   const { mutateAsync: updateCollection } = useUpdateCollection();
   const { mutateAsync: deleteCollection } = useDeleteCollection();
   const { mutateAsync: updateBookmarkAsync } = useUpdateBookmark();
@@ -72,6 +83,19 @@ export function CollectionDetailContent({ id }: Props) {
         <div className="mx-auto max-w-7xl px-4 py-10">
           <div className="h-8 w-48 animate-pulse rounded-xl bg-zinc-200 dark:bg-zinc-800" />
         </div>
+      </div>
+    );
+  }
+
+  if (colError) {
+    return (
+      <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
+        <ErrorState
+          title="컬렉션을 불러오지 못했어요"
+          description="네트워크 문제일 수 있어요. 다시 시도해 주세요."
+          onRetry={() => refetchCol()}
+          className="min-h-screen"
+        />
       </div>
     );
   }
@@ -186,7 +210,14 @@ export function CollectionDetailContent({ id }: Props) {
         </div>
 
         {/* 북마크 목록 */}
-        {bkLoading ? (
+        {bkError ? (
+          <ErrorState
+            title="북마크를 불러오지 못했어요"
+            description="네트워크 문제일 수 있어요. 다시 시도해 주세요."
+            onRetry={() => refetchBk()}
+            className="py-20"
+          />
+        ) : bkLoading ? (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 3 }).map((_, i) => (
               <div

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -31,6 +31,8 @@ export const Header = ({ initialUser }: { initialUser: User | null }) => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [showMobileSearch, setShowMobileSearch] = useState(false);
   const [isLoggingOut, setIsLoggingOut] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const {
@@ -141,6 +143,23 @@ export const Header = ({ initialUser }: { initialUser: User | null }) => {
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, []);
+
+  // 유저 메뉴: 외부 클릭 / ESC로 닫기 (hover 전용이던 것을 클릭 토글로 전환)
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [menuOpen]);
 
   const handleLogin = () => router.push("/login");
 
@@ -270,29 +289,51 @@ export const Header = ({ initialUser }: { initialUser: User | null }) => {
                   {nickname}님
                 </span>
               </div>
-              <div className="group relative cursor-pointer">
-                <Avatar username={nickname} src={currentUser?.user_metadata?.avatar_url} />
-                <div className="animate-in fade-in zoom-in-95 absolute top-full right-0 hidden pt-2 duration-200 group-hover:block">
-                  <div className="bg-surface-card dark:bg-surface-card-dark flex min-w-[140px] flex-col gap-1 rounded-2xl border border-zinc-200 p-1.5 shadow-xl dark:border-zinc-800">
-                    {isGuest && (
+              <div className="relative" ref={menuRef}>
+                <button
+                  type="button"
+                  onClick={() => setMenuOpen((v) => !v)}
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  aria-label="사용자 메뉴"
+                  className="flex cursor-pointer items-center rounded-full"
+                >
+                  <Avatar username={nickname} src={currentUser?.user_metadata?.avatar_url} />
+                </button>
+                {menuOpen && (
+                  <div
+                    role="menu"
+                    className="animate-in fade-in zoom-in-95 absolute top-full right-0 pt-2 duration-200"
+                  >
+                    <div className="bg-surface-card dark:bg-surface-card-dark flex min-w-[140px] flex-col gap-1 rounded-2xl border border-zinc-200 p-1.5 shadow-xl dark:border-zinc-800">
+                      {isGuest && (
+                        <button
+                          role="menuitem"
+                          onClick={() => {
+                            setMenuOpen(false);
+                            handleGuestLogin();
+                          }}
+                          className="text-brand-primary hover:bg-brand-primary/5 flex cursor-pointer items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors"
+                        >
+                          <PlusIcon />
+                          <span>로그인/회원가입</span>
+                        </button>
+                      )}
                       <button
-                        onClick={handleGuestLogin}
-                        className="text-brand-primary hover:bg-brand-primary/5 flex cursor-pointer items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors"
+                        role="menuitem"
+                        onClick={() => {
+                          setMenuOpen(false);
+                          handleLogout();
+                        }}
+                        disabled={isLoggingOut}
+                        className="text-status-error hover:bg-status-error/5 flex cursor-pointer items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        <PlusIcon />
-                        <span>로그인/회원가입</span>
+                        <LogOutIcon />
+                        <span>{isLoggingOut ? "로그아웃 중..." : "로그아웃"}</span>
                       </button>
-                    )}
-                    <button
-                      onClick={handleLogout}
-                      disabled={isLoggingOut}
-                      className="text-status-error hover:bg-status-error/5 flex cursor-pointer items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      <LogOutIcon />
-                      <span>{isLoggingOut ? "로그아웃 중..." : "로그아웃"}</span>
-                    </button>
+                    </div>
                   </div>
-                </div>
+                )}
               </div>
             </div>
           ) : (

--- a/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
@@ -38,7 +38,17 @@ export const BookmarkCard = ({
   return (
     <div
       onClick={() => !isPending && onClick?.(bookmark)}
-      className={`group relative flex h-full w-full flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white transition-all ${isPending ? "cursor-wait opacity-90" : "cursor-pointer hover:-translate-y-1 hover:shadow-2xl"} shadow-sm dark:border-zinc-800 dark:bg-zinc-900`}
+      onKeyDown={(e) => {
+        if (isPending) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.(bookmark);
+        }
+      }}
+      role="button"
+      tabIndex={isPending ? -1 : 0}
+      aria-label={`북마크: ${title}`}
+      className={`group relative flex h-full w-full flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white transition-all ${isPending ? "cursor-wait opacity-90" : "cursor-pointer hover:-translate-y-1 hover:shadow-2xl"} focus-visible:ring-brand-primary shadow-sm focus-visible:ring-2 focus-visible:outline-none dark:border-zinc-800 dark:bg-zinc-900`}
     >
       {/* 1. Thumbnail Area */}
       <div className="relative aspect-[16/10] w-full overflow-hidden bg-zinc-50 dark:bg-zinc-800/50">

--- a/apps/web/src/widgets/home/ui/HomeContent.tsx
+++ b/apps/web/src/widgets/home/ui/HomeContent.tsx
@@ -15,12 +15,13 @@ import {
 import { useBookmarkPipeline } from "@/features/bookmark/model/useBookmarkPipeline";
 import { overlay } from "@/shared/lib/overlay/overlay";
 import { AddBookmarkOverlay } from "@/features/bookmark/ui/AddBookmarkOverlay";
+import { ErrorState } from "@/shared/ui/ErrorState";
 import type { Bookmark } from "@/entities/bookmark/model/types";
 
 export function HomeContent() {
   const router = useRouter();
   const { selectedBookmarkId, setSelectedBookmarkId } = useBookmarkStore();
-  const { data: bookmarks = [], isLoading } = useBookmarks();
+  const { data: bookmarks = [], isLoading, isError, refetch } = useBookmarks();
   const { mutate: updateBookmark, mutateAsync: updateBookmarkAsync } = useUpdateBookmark();
   const { mutateAsync: deleteBookmarkAsync } = useDeleteBookmark();
   const { runPipeline, patchCache } = useBookmarkPipeline();
@@ -99,36 +100,47 @@ export function HomeContent() {
       />
 
       <main className="pb-20">
-        <RecentBookmarkSlider
-          bookmarks={recentBookmarks}
-          onBookmarkClick={handleBookmarkClick}
-          onTagClick={handleTagClick}
-        />
-
-        <section className="mx-auto max-w-7xl border-t border-zinc-200 px-4 py-8 sm:px-6 lg:px-8 dark:border-zinc-800">
-          <div className="mb-6 flex items-baseline gap-2">
-            <h2 className="text-2xl font-black tracking-tight text-zinc-900 dark:text-white">
-              나의 모든 북마크
-            </h2>
-            <span className="text-sm text-zinc-400 dark:text-zinc-500">
-              {allBookmarks.length}개
-            </span>
-          </div>
-          <BookmarkList
-            bookmarks={allBookmarks}
-            isLoading={isLoading}
-            onBookmarkClick={handleBookmarkClick}
-            onTagClick={handleTagClick}
-            onRetry={handleRetry}
-            getRetryExhausted={(id) => exhaustedIds.has(id)}
-            emptyMessage="북마크를 추가하세요."
-            onAddClick={() =>
-              overlay.open(({ isOpen, close }) => (
-                <AddBookmarkOverlay isOpen={isOpen} onClose={close} />
-              ))
-            }
+        {isError ? (
+          <ErrorState
+            title="북마크를 불러오지 못했어요"
+            description="네트워크 문제일 수 있어요. 다시 시도해 주세요."
+            onRetry={() => refetch()}
+            className="min-h-[60vh]"
           />
-        </section>
+        ) : (
+          <>
+            <RecentBookmarkSlider
+              bookmarks={recentBookmarks}
+              onBookmarkClick={handleBookmarkClick}
+              onTagClick={handleTagClick}
+            />
+
+            <section className="mx-auto max-w-7xl border-t border-zinc-200 px-4 py-8 sm:px-6 lg:px-8 dark:border-zinc-800">
+              <div className="mb-6 flex items-baseline gap-2">
+                <h2 className="text-2xl font-black tracking-tight text-zinc-900 dark:text-white">
+                  나의 모든 북마크
+                </h2>
+                <span className="text-sm text-zinc-400 dark:text-zinc-500">
+                  {allBookmarks.length}개
+                </span>
+              </div>
+              <BookmarkList
+                bookmarks={allBookmarks}
+                isLoading={isLoading}
+                onBookmarkClick={handleBookmarkClick}
+                onTagClick={handleTagClick}
+                onRetry={handleRetry}
+                getRetryExhausted={(id) => exhaustedIds.has(id)}
+                emptyMessage="북마크를 추가하세요."
+                onAddClick={() =>
+                  overlay.open(({ isOpen, close }) => (
+                    <AddBookmarkOverlay isOpen={isOpen} onClose={close} />
+                  ))
+                }
+              />
+            </section>
+          </>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## 📝 무엇을 만들었나요

데이터 로드 실패를 "빈 상태" 대신 에러/재시도 UI로 보여주고, 모바일·키보드 접근성을 개선했습니다.

## 🚀 주요 변경 사항

- [x] **로드 실패 에러 UI**: react-query `isError`를 4개 화면에서 처리해 `ErrorState`(재시도 포함)로 대체 — Home / Bookmarks / Collections / CollectionDetail. CollectionDetail은 "load 에러"와 "not found"를 분리
- [x] **Header 모바일 로그아웃 버그**: hover 전용 메뉴 → 클릭 토글 (모바일·키보드에서 로그아웃 불가하던 기능 버그 해결). aria-haspopup/expanded, role=menu, 외부클릭·ESC로 닫기
- [x] **BookmarkCard 키보드 접근**: `div onClick` → role=button + tabIndex + Enter/Space 핸들러 + focus-visible 링

## 🔗 관련 이슈

- Fixes #

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수 (상위 레이어 → 하위 레이어만 import)
- [x] 타입 에러 없음 (\`pnpm typecheck\`)
- [x] 린트 통과 (\`pnpm lint\`)
- [x] 불필요한 console.log 제거