### PR TITLE
feat: 상세 패널 접근성 + 작업 실패 toast 피드백

### DIFF
--- a/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
+++ b/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
@@ -16,6 +16,7 @@ import { BookmarkDetailPanel } from "@/entities/bookmark/ui/BookmarkDetailPanel"
 import { useUpdateBookmark } from "@/features/bookmark/model/queries";
 import { supabase } from "@/shared/api/supabase/client";
 import { ErrorState } from "@/shared/ui/ErrorState";
+import { toast } from "@/shared/lib/toast";
 import { useEffect } from "react";
 import type { Bookmark } from "@/entities/bookmark/model/types";
 
@@ -67,14 +68,22 @@ export function CollectionDetailContent({ id }: Props) {
 
   const handleSaveName = async () => {
     if (!editName.trim() || !collection) return;
-    await updateCollection({ id, name: editName.trim() });
-    setIsEditingName(false);
+    try {
+      await updateCollection({ id, name: editName.trim() });
+      setIsEditingName(false);
+    } catch {
+      toast.show({ message: "이름을 변경하지 못했어요. 다시 시도해주세요." });
+    }
   };
 
   const handleDelete = async () => {
     if (!confirm("컬렉션을 삭제할까요? 북마크는 삭제되지 않습니다.")) return;
-    await deleteCollection(id);
-    router.push("/collections");
+    try {
+      await deleteCollection(id);
+      router.push("/collections");
+    } catch {
+      toast.show({ message: "컬렉션을 삭제하지 못했어요. 다시 시도해주세요." });
+    }
   };
 
   if (colLoading) {

--- a/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
@@ -63,6 +63,7 @@ export const BookmarkDetailPanel = ({
       setIsEditing(false);
     } catch (err) {
       console.error("[BookmarkDetailPanel] 저장 실패:", err);
+      toast.show({ message: "저장하지 못했어요. 다시 시도해주세요." });
     } finally {
       setIsSaving(false);
     }
@@ -104,14 +105,21 @@ export const BookmarkDetailPanel = ({
   const isOpen = !!bookmark;
 
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = "hidden";
-    } else {
+    if (!isOpen) {
       document.body.style.overflow = "";
+      return;
     }
+    document.body.style.overflow = "hidden";
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    document.addEventListener("keydown", handleKey);
     return () => {
       document.body.style.overflow = "";
+      document.removeEventListener("keydown", handleKey);
     };
+    // handleClose는 안정적인 setter만 호출하므로 deps 생략
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   return (
@@ -121,6 +129,9 @@ export const BookmarkDetailPanel = ({
       )}
 
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="북마크 상세"
         className={`fixed top-0 right-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-zinc-900 ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
@@ -132,6 +143,7 @@ export const BookmarkDetailPanel = ({
             {!isEditing ? (
               <button
                 onClick={handleEditStart}
+                aria-label="편집"
                 className="rounded-xl p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
               >
                 <Pencil size={18} />
@@ -139,6 +151,7 @@ export const BookmarkDetailPanel = ({
             ) : (
               <button
                 onClick={handleEditCancel}
+                aria-label="편집 취소"
                 className="rounded-xl p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-red-500 dark:hover:bg-zinc-800"
               >
                 <XCircle size={18} />
@@ -146,6 +159,7 @@ export const BookmarkDetailPanel = ({
             )}
             <button
               onClick={handleClose}
+              aria-label="닫기"
               className="rounded-xl p-2 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
             >
               <X size={18} />
@@ -203,6 +217,7 @@ export const BookmarkDetailPanel = ({
                       onClick={handleCopyUrl}
                       className="shrink-0 rounded-lg p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
                       title="URL 복사"
+                      aria-label="URL 복사"
                     >
                       {isCopied ? (
                         <CopyCheck size={14} className="text-green-500" />

--- a/apps/web/src/features/collection/ui/AddToCollectionButton.tsx
+++ b/apps/web/src/features/collection/ui/AddToCollectionButton.tsx
@@ -8,6 +8,7 @@ import {
   useRemoveBookmarkFromCollection,
   useCollectionBookmarks,
 } from "../model/queries";
+import { toast } from "@/shared/lib/toast";
 
 interface Props {
   bookmarkId: string;
@@ -48,11 +49,17 @@ export const AddToCollectionButton = ({ bookmarkId }: Props) => {
                   name={col.name}
                   bookmarkId={bookmarkId}
                   onAdd={() => {
-                    addBookmark({ collectionId: col.id, bookmarkId });
+                    addBookmark(
+                      { collectionId: col.id, bookmarkId },
+                      { onError: () => toast.show({ message: "컬렉션에 추가하지 못했어요." }) }
+                    );
                     setOpen(false);
                   }}
                   onRemove={() => {
-                    removeBookmark({ collectionId: col.id, bookmarkId });
+                    removeBookmark(
+                      { collectionId: col.id, bookmarkId },
+                      { onError: () => toast.show({ message: "컬렉션에서 제거하지 못했어요." }) }
+                    );
                   }}
                 />
               ))}

--- a/apps/web/src/features/collection/ui/CreateCollectionModal.tsx
+++ b/apps/web/src/features/collection/ui/CreateCollectionModal.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { X, Folder } from "lucide-react";
 import { useCreateCollection } from "../model/queries";
+import { toast } from "@/shared/lib/toast";
 
 interface Props {
   onClose: () => void;
@@ -16,8 +17,12 @@ export const CreateCollectionModal = ({ onClose }: Props) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
-    await mutateAsync({ name: name.trim(), description: description.trim() || undefined });
-    onClose();
+    try {
+      await mutateAsync({ name: name.trim(), description: description.trim() || undefined });
+      onClose();
+    } catch {
+      toast.show({ message: "컬렉션을 만들지 못했어요. 다시 시도해주세요." });
+    }
   };
 
   return (

--- a/apps/web/src/features/collection/ui/InviteMemberModal.tsx
+++ b/apps/web/src/features/collection/ui/InviteMemberModal.tsx
@@ -8,6 +8,7 @@ import type {
   CollectionRole,
 } from "@/entities/collection/model/types";
 import { useInviteMember, useUpdateMemberRole, useRemoveMember } from "../model/queries";
+import { toast } from "@/shared/lib/toast";
 
 interface Props {
   collection: CollectionDetail;
@@ -63,11 +64,19 @@ export const InviteMemberModal = ({ collection, currentUserId, onClose }: Props)
   };
 
   const handleRoleChange = async (member: CollectionMember, newRole: CollectionRole) => {
-    await updateRole({ collectionId: collection.id, userId: member.userId, role: newRole });
+    try {
+      await updateRole({ collectionId: collection.id, userId: member.userId, role: newRole });
+    } catch {
+      toast.show({ message: "역할을 변경하지 못했어요. 다시 시도해주세요." });
+    }
   };
 
   const handleRemove = async (member: CollectionMember) => {
-    await removeMember({ collectionId: collection.id, userId: member.userId });
+    try {
+      await removeMember({ collectionId: collection.id, userId: member.userId });
+    } catch {
+      toast.show({ message: "멤버를 제거하지 못했어요. 다시 시도해주세요." });
+    }
   };
 
   return (


### PR DESCRIPTION
## 📝 무엇을 만들었나요

북마크 상세 패널의 키보드 접근성을 보완하고, 실패해도 성공한 듯 보이던 작업들에 실패 알림(toast)을 추가했습니다.

## 🚀 주요 변경 사항

- [x] **BookmarkDetailPanel 접근성**: ESC로 닫기(다른 오버레이엔 있던 것), role=dialog + aria-modal + aria-label, 편집/닫기/URL복사 버튼 aria-label
- [x] **저장 실패 피드백**: 패널 저장 실패 시 console.error만 하던 것 → toast
- [x] **컬렉션 작업 실패 피드백**: 생성/이름변경/삭제/추가/제거/역할변경/멤버제거가 실패해도 무반응이던 것 → toast로 알림 (CreateCollectionModal, CollectionDetailContent, AddToCollectionButton, InviteMemberModal)

## 🔗 관련 이슈

- Fixes #

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음 (\`pnpm typecheck\`)
- [x] 린트 통과 (\`pnpm lint\`)
- [x] 불필요한 console.log 제거