### PR TITLE
feat: SEO 세팅 + 성능/견고성 개선

### DIFF
--- a/apps/web/src/app/(main)/bookmarks/BookmarksContent.tsx
+++ b/apps/web/src/app/(main)/bookmarks/BookmarksContent.tsx
@@ -17,6 +17,7 @@ import { useBookmarkStore } from "@/entities/bookmark/model/useBookmarkStore";
 import { supabase } from "@/shared/api/supabase/client";
 import storage from "@/shared/lib/storage";
 import { ErrorState } from "@/shared/ui/ErrorState";
+import { toast } from "@/shared/lib/toast";
 import type { Bookmark } from "@/entities/bookmark/model/types";
 import { X } from "lucide-react";
 
@@ -90,9 +91,12 @@ export function BookmarksContent() {
         if (json.success) {
           setSemanticExact(json.data.exact);
           setSemanticRelated(json.data.related);
+        } else {
+          toast.show({ message: "AI 검색에 실패했어요. 잠시 후 다시 시도해주세요." });
         }
       } catch (e) {
         console.error("[SemanticSearch] 오류:", e);
+        toast.show({ message: "AI 검색에 실패했어요. 잠시 후 다시 시도해주세요." });
       } finally {
         setSemanticLoading(false);
       }

--- a/apps/web/src/app/(main)/collections/[id]/page.tsx
+++ b/apps/web/src/app/(main)/collections/[id]/page.tsx
@@ -1,6 +1,11 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import { CollectionDetailContent } from "./CollectionDetailContent";
 import { PageLoadingSkeleton } from "@/shared/ui/PageLoadingSkeleton";
+
+export const metadata: Metadata = {
+  title: "컬렉션",
+};
 
 export default async function CollectionDetailPage({
   params,

--- a/apps/web/src/app/(main)/collections/page.tsx
+++ b/apps/web/src/app/(main)/collections/page.tsx
@@ -1,6 +1,12 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import { CollectionsContent } from "./CollectionsContent";
 import { PageLoadingSkeleton } from "@/shared/ui/PageLoadingSkeleton";
+
+export const metadata: Metadata = {
+  title: "컬렉션",
+  description: "북마크를 컬렉션으로 묶고 팀과 함께 관리하세요.",
+};
 
 export default function CollectionsPage() {
   return (

--- a/apps/web/src/app/api/extension/_lib/pipeline.ts
+++ b/apps/web/src/app/api/extension/_lib/pipeline.ts
@@ -40,15 +40,20 @@ export async function runPipeline(supabase: SupabaseClient, bookmarkId: string, 
   const tags: string[] = aiData.tags ?? [];
   console.log("[Pipeline] AI 분석 완료 - title:", finalTitle, "tags:", tags);
 
-  // 태그 저장
-  for (const name of tags) {
-    const { data: tag } = await supabase
+  // 태그 저장 — 태그별 순차 왕복(2N) 대신 배치 upsert 2회로 처리
+  if (tags.length > 0) {
+    const { data: tagRows } = await supabase
       .from("tags")
-      .upsert({ name }, { onConflict: "name" })
-      .select("id")
-      .single();
-    if (tag) {
-      await supabase.from("bookmark_tags").upsert({ bookmark_id: bookmarkId, tag_id: tag.id });
+      .upsert(
+        tags.map((name) => ({ name })),
+        { onConflict: "name" }
+      )
+      .select("id");
+
+    if (tagRows && tagRows.length > 0) {
+      await supabase
+        .from("bookmark_tags")
+        .upsert(tagRows.map((t) => ({ bookmark_id: bookmarkId, tag_id: t.id })));
     }
   }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -14,6 +14,11 @@ import { SpeedInsights } from "@vercel/speed-insights/next";
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://smart-bookmark-app-hdz6.vercel.app";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "SmartMark — AI 북마크 관리",
+    template: "%s | SmartMark",
+  },
   description: "저장은 했는데, 어디 있는지 모르겠다고요? AI가 내용을 읽고 의미로 찾아드려요.",
   openGraph: {
     type: "website",

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://smart-bookmark-app-hdz6.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/", "/auth/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://smart-bookmark-app-hdz6.vercel.app";
+
+/**
+ * 공개(비인증) 페이지만 색인 대상으로 노출.
+ * /bookmarks·/collections 등은 인증 게이트 + 동적이라 제외한다.
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const publicRoutes = ["", "/landing", "/login", "/privacy"];
+
+  return publicRoutes.map((path) => ({
+    url: `${SITE_URL}${path}`,
+    changeFrequency: "monthly",
+    priority: path === "" ? 1 : 0.6,
+  }));
+}

--- a/apps/web/src/features/bookmark/ui/AddBookmarkOverlay.tsx
+++ b/apps/web/src/features/bookmark/ui/AddBookmarkOverlay.tsx
@@ -5,7 +5,7 @@ import { bookmarkService } from "../model/bookmark.service";
 import { bookmarkKeys } from "../model/queries";
 import { useBookmarkPipeline } from "../model/useBookmarkPipeline";
 import { validateUrl } from "@/shared/lib/validateUrl";
-import { getErrorMessage } from "@/shared/lib/error";
+import { BookmarkError, BookmarkErrorCode } from "@/entities/bookmark/model/bookmark.error";
 import { useRouter } from "next/navigation";
 import { toast } from "@/shared/lib/toast";
 import { useQueryClient } from "@tanstack/react-query";
@@ -96,8 +96,8 @@ export const AddBookmarkOverlay = ({ isOpen, onClose }: AddBookmarkOverlayProps)
         }
       }
     } catch (error: unknown) {
-      const msg = getErrorMessage(error);
-      if (msg.includes("무료 체험 한도")) {
+      // 문자열 매칭 대신 에러 코드로 판별 (메시지 문구가 바뀌어도 안전)
+      if (error instanceof BookmarkError && error.code === BookmarkErrorCode.GUEST_LIMIT_EXCEEDED) {
         setIsLimitReached(true);
       } else {
         console.error(error);


### PR DESCRIPTION
## 📝 무엇을 만들었나요

SEO 기본 세팅(sitemap/robots/metadata)과 자잘한 성능·견고성 개선을 했습니다.

## 🚀 주요 변경 사항

- [x] **SEO**: `sitemap.ts`·`robots.ts` 추가(공개 페이지만 색인), 루트 metadataBase + title 템플릿, 컬렉션 페이지 metadata (탭 제목 폴백 해결)
- [x] **N+1 개선**: 파이프라인 태그 저장을 태그별 순차 왕복(2N) → 배치 upsert 2회로
- [x] **시맨틱 검색 실패 피드백**: 무반응이던 것 → toast 알림
- [x] **에러코드 판별**: 게스트 한도 판별을 에러 메시지 문자열 매칭 → `BookmarkErrorCode` 기반 (문구 바뀌어도 안전)

## 🔗 관련 이슈

- Fixes #

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음 (\`pnpm typecheck\`)
- [x] 린트 통과 (\`pnpm lint\`)
- [x] 불필요한 console.log 제거