### PR TITLE
fix: 다크모드 세이프에어리어 흰 띠 제거

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Toaster } from "@/shared/ui/Toaster";
 // 페이지에 실제 등장한 글자가 속한 조각(woff2)만 다운로드됨
 import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 import "@/styles/globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -39,6 +39,14 @@ export const metadata: Metadata = {
     icon: "/favicon.svg",
     other: { rel: "alternate icon", url: "/favicon.ico" },
   },
+};
+
+// iOS Safari 상태바 tint를 앱 배경과 맞춰 세이프에어리어 흰 띠를 없앤다 (라이트/다크)
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fafafa" },
+    { media: "(prefers-color-scheme: dark)", color: "#09090b" },
+  ],
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -80,9 +80,14 @@
     color: #18181b;
   }
 
-  .dark body {
-    background-color: var(--color-surface-base-dark);
-    color: #fafafa;
+  /* 다크모드는 OS prefers-color-scheme 기반(클래스 토글 미사용)이라 body도 media query로 맞춘다.
+     .dark body 셀렉터는 .dark 클래스가 없어 적용되지 않으며, 이때 흰 body가
+     iOS 세이프에어리어(상단 상태바·하단 홈인디케이터)에 비쳐 흰 띠로 보였다. */
+  @media (prefers-color-scheme: dark) {
+    body {
+      background-color: var(--color-surface-base-dark);
+      color: #fafafa;
+    }
   }
 }
 


### PR DESCRIPTION
## 📝 무엇을 만들었나요

다크모드에서 iOS 세이프에어리어(상단 상태바·하단 홈인디케이터)가 흰색으로 보이던 문제 수정.

## 🚀 주요 변경 사항

- [x] body 다크 배경을 `.dark` 클래스 셀렉터 → `prefers-color-scheme` media query로 전환 (html과 동일 방식). 앱이 클래스 토글을 안 쓰는데 `.dark body`로만 걸려 있어 body가 흰색으로 남던 것이 근본 원인.
- [x] `theme-color` 메타(라이트 #fafafa / 다크 #09090b) 추가 — iOS Safari 상태바 tint를 배경과 일치.

## ✅ 체크리스트

- [x] 타입 에러 없음
- [x] 린트 통과