### PR TITLE
release: 다크모드 세이프에어리어 흰 띠 제거

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { Toaster } from "@/shared/ui/Toaster";
 // 페이지에 실제 등장한 글자가 속한 조각(woff2)만 다운로드됨
 import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 import "@/styles/globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -39,6 +39,14 @@ export const metadata: Metadata = {
     icon: "/favicon.svg",
     other: { rel: "alternate icon", url: "/favicon.ico" },
   },
+};
+
+// iOS Safari 상태바 tint를 앱 배경과 맞춰 세이프에어리어 흰 띠를 없앤다 (라이트/다크)
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fafafa" },
+    { media: "(prefers-color-scheme: dark)", color: "#09090b" },
+  ],
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -80,9 +80,14 @@
     color: #18181b;
   }
 
-  .dark body {
-    background-color: var(--color-surface-base-dark);
-    color: #fafafa;
+  /* 다크모드는 OS prefers-color-scheme 기반(클래스 토글 미사용)이라 body도 media query로 맞춘다.
+     .dark body 셀렉터는 .dark 클래스가 없어 적용되지 않으며, 이때 흰 body가
+     iOS 세이프에어리어(상단 상태바·하단 홈인디케이터)에 비쳐 흰 띠로 보였다. */
+  @media (prefers-color-scheme: dark) {
+    body {
+      background-color: var(--color-surface-base-dark);
+      color: #fafafa;
+    }
   }
 }
 


### PR DESCRIPTION
## 🚢 릴리즈 요약

다크모드에서 iOS 세이프에어리어(상단 상태바·하단 홈인디케이터)가 흰색으로 보이던 문제 수정. 실기기 확인 완료.

## 📦 주요 변경사항

- body 다크 배경을 prefers-color-scheme media query로 전환 (하단 흰 띠 제거)
- theme-color 메타(라이트/다크) 추가 (상단 상태바 tint 일치)

## ⚠️ 변경 (Breaking Changes)

없음

## ✅ 배포 전 체크리스트

- [x] dev 브랜치에서 실기기 확인 완료
- [x] CI (lint / typecheck / test) 전부 통과
- [x] 환경변수 변경사항 없음
- [x] 마이그레이션 없음 (CSS + meta만 변경)