### PR TITLE
docs: 002/003/006 결정 문서 날카롭게 (교과서 도입부 제거)

### DIFF
--- a/docs/decisions/002-design-pattern.md
+++ b/docs/decisions/002-design-pattern.md
@@ -1,16 +1,17 @@
-# Repository 패턴
+# 저장소 추상화 — Repository · Factory · DI
 
-DB 접근 코드를 한 곳에 모아두는 패턴.
+> 비회원(localStorage)과 회원(Supabase) 두 저장소를 **UI 변경 없이 교체**하기 위해 선택한 패턴 3종과 근거.
 
-> "함께 바뀌는 코드는 함께 있어야 한다"
+---
 
-## 왜 필요한가
+## Repository 패턴 — UI가 저장소를 모르게
 
-- UI → Supabase 직접 알면 안 됨
-- UI → 뒤가 뭔지 몰라야 함
-- 뒤가 바뀌어도 앞이 안 바뀌어야 함
+DB 접근 코드를 한 곳에 모으고, UI는 인터페이스만 알게 한다. 뒤(저장소)가 바뀌어도 앞(UI)이 안 바뀌게 하려는 것.
 
-## 구조
+- UI가 Supabase를 직접 알면 안 됨 → 저장소 교체 시 UI까지 수정해야 함
+- 뒤가 바뀌어도 앞은 그대로 (localStorage → Supabase 전환에도 호출부 불변)
+
+### 구조
 
 ```
 UI
@@ -21,7 +22,7 @@ LocalRepository      SupabaseRepository
 (localStorage)         (Supabase)
 ```
 
-## BookmarkRepository 인터페이스
+### BookmarkRepository 인터페이스
 
 ```ts
 interface BookmarkRepository {
@@ -40,7 +41,7 @@ interface BookmarkRepository {
 2. 새로운 팀원이 헷갈려한다
 3. 디버깅이 좀 어려워진다.
 
-## 왜 Promise로 통일하나
+### 왜 Promise로 통일하나 (동기 Local + 비동기 Supabase)
 
 | 구현체   | 특성                                      |
 | -------- | ----------------------------------------- |
@@ -53,12 +54,9 @@ interface BookmarkRepository {
 
 ---
 
-# Factory 패턴
+## Factory 패턴 — 구현체 선택을 한 곳에서
 
-조건에 따라 어떤 구현체를 줄지 결정하는 패턴.
-`bookmark.service.ts`가 이 역할을 한다.
-
-이렇게 빼지 않으면 이런식으로 모든 곳에서 전부다 고쳐야된다
+세션 유무로 어떤 구현체를 줄지 `bookmark.service.ts`가 결정한다. 이렇게 빼지 않으면 아래처럼 모든 호출부에서 분기를 반복해야 한다.
 
 ```ts
 // 컴포넌트 안에서
@@ -87,18 +85,16 @@ class BookmarkService {
 
 ---
 
-# 의존성 주입 (Dependency Injection)
+## 의존성 주입 (DI) — 생성 시점에 필요한 값 주입
 
-생성될 때 외부에서 필요한 값을 주입받는 패턴.
-
-## 파라미터 주입 vs 생성자 주입
+### 파라미터 주입 vs 생성자 주입
 
 | 기준                             | 방식            |
 | -------------------------------- | --------------- |
 | 매번 바뀌는 값 (필터, 검색 조건) | 파라미터로 받기 |
 | 생성 시 정해지는 값 (userId)     | 생성자로 받기   |
 
-## SupabaseRepository 예시
+### SupabaseRepository 예시
 
 ```ts
 class SupabaseRepository implements BookmarkRepository {
@@ -111,7 +107,7 @@ class SupabaseRepository implements BookmarkRepository {
 }
 ```
 
-## 생성자가 별로인 경우
+### 생성자가 별로인 경우
 
 > 생성자 파라미터가 너무 많으면 **"이 클래스가 너무 많은 걸 알고 있다"** 는 신호.
 > 설계를 다시 나눠야 함.

--- a/docs/decisions/003-typescript-utility-types.md
+++ b/docs/decisions/003-typescript-utility-types.md
@@ -1,55 +1,10 @@
-# TypeScript Utility Types
+# TypeScript 타입 설계 결정
 
-> 프로젝트에서 직접 마주친 문제를 해결하면서 정리한 Utility Types 가이드
-
----
-
-## Utility Types가 뭔가
-
-TypeScript가 기본으로 제공하는 **타입 변환 도구**예요.
-기존 타입을 변형해서 새 타입을 만들어요.
+> Repository 패턴에서 마주친 두 가지 타입 설계 결정 — update 타입으로 "변경 가능 범위"를 제한하고, save 요청 타입을 공통화한 이유.
 
 ---
 
-## 자주 쓰는 것들
-
-### Partial — 모든 필드를 옵셔널로
-
-```ts
-interface Bookmark {
-  id: string;
-  title: string;
-  summary: string;
-}
-
-type PartialBookmark = Partial<Bookmark>;
-// 결과: { id?: string, title?: string, summary?: string }
-```
-
-### Omit — 특정 필드 제거
-
-```ts
-type LocalBookmark = Omit<Bookmark, "userId" | "tempUserId">;
-// userId, tempUserId가 빠진 Bookmark
-```
-
-### Pick — 특정 필드만 선택
-
-```ts
-type BookmarkId = Pick<Bookmark, "id">;
-// 결과: { id: string }
-```
-
-### Required — 모든 필드를 필수로
-
-```ts
-type RequiredBookmark = Required<Bookmark>;
-// 모든 옵셔널이 필수로 바뀜
-```
-
----
-
-## 실제 문제 상황 — update 타입 설계
+## 결정 1 — update 타입: 변경 가능 범위를 타입으로 제한
 
 ### 문제
 
@@ -126,13 +81,9 @@ AI 처리 결과 타입     → Pick<Bookmark, 'title' | 'summary' | 'tags'>
 전부 입력 강제할 때   → Required<T>
 ```
 
-# 타입 설계 결정 기록
+## 결정 2 — save 요청 타입: 공통 타입 vs 분리
 
-> Repository 패턴 적용 시 요청 타입을 어떻게 설계할 것인가
-
----
-
-## 문제 상황
+> Repository 인터페이스의 `save` 메서드 파라미터를 어떻게 설계할 것인가
 
 `BookmarkRepository` 인터페이스의 `save` 메서드 파라미터 타입을 결정해야 했어요.
 
@@ -262,16 +213,4 @@ async save(request: CreateBookmarkRequest): Promise<Bookmark> {
   if (!request.guestId) throw new Error('guestId가 필요합니다')
   // ...
 }
-```
-
----
-
-## 관련 개념
-
-```
-Union Type    → A | B 둘 중 하나
-Intersection  → A & B 둘 다
-Partial       → 모든 필드 옵셔널
-Pick          → 특정 필드만 선택
-Omit          → 특정 필드 제거
 ```

--- a/docs/decisions/006-헤드리스패턴-적용하기.md
+++ b/docs/decisions/006-헤드리스패턴-적용하기.md
@@ -1,11 +1,10 @@
-# 📚 헤드리스 컴포넌트 설계 사전 학습
+# 헤드리스 패턴으로 Input 로직/스타일 분리
 
-> Input 컴포넌트 헤드리스 리팩토링 + Storybook 도입 전 개념 정리  
-> `components/ui/input` 리팩토링 시작 전 작성
+> `Input` 컴포넌트의 로직과 스타일을 분리해, 디자인이 바뀌어도 동작 코드는 건드리지 않게 만든 리팩토링 결정.
 
 ---
 
-## 왜 이걸 공부했나
+## 왜 이 구조를 택했나
 
 shadcn의 GitHub 소스를 보다가 Radix UI(헤드리스)를 한 번 더 감싸서 스타일을 입히는 구조를 발견했다. 기존 `Input` 컴포넌트가 로직과 스타일이 섞여있어서 디자인이 바뀌면 같이 수정해야 하는 구조였고, 이를 개선하기 위해 헤드리스 패턴을 직접 적용하기로 결정했다.
 
@@ -153,36 +152,9 @@ const { register } = useForm()
 
 ---
 
-## 4. Storybook 기본 개념
+## 4. Storybook — 문서화할 상태 케이스
 
-### Story란
-
-컴포넌트의 "상태 스냅샷"이다. 하나의 컴포넌트가 가질 수 있는 모든 경우의 수를 문서화한다.
-
-```tsx
-// Input.stories.tsx
-export default {
-  title: "UI/Input",
-  component: Input,
-};
-
-// 각 Story = 하나의 케이스
-export const Default = {};
-
-export const WithError = {
-  args: { error: "이메일 형식이 올바르지 않습니다." },
-};
-
-export const WithIcon = {
-  args: { icon: <MailIcon /> },
-};
-
-export const Disabled = {
-  args: { disabled: true },
-};
-```
-
-### 체크해야 할 Story 케이스 (Input 기준)
+컴포넌트가 가질 수 있는 상태를 Story로 문서화한다. Input 기준 체크 케이스:
 
 ```
 Default          → 기본 상태
@@ -193,19 +165,6 @@ Disabled         → 비활성화
 Focus            → 포커스 상태
 ErrorWithIcon    → 아이콘 + 에러 동시
 ```
-
-### args와 controls
-
-```tsx
-export default {
-  argTypes: {
-    error: { control: "text" }, // Storybook UI에서 직접 수정 가능
-    disabled: { control: "boolean" },
-  },
-};
-```
-
-Storybook UI에서 실시간으로 props를 바꿔보면서 테스트할 수 있다.
 
 ---
 
@@ -274,29 +233,8 @@ components/ui/input/
 
 ---
 
-## 학습 우선순위
-
-```
-지금 당장 (코드 치기 전)
-  ✅ forwardRef 이유
-  ✅ Compound Component 개념
-  ✅ aria-invalid, aria-describedby
-
-Storybook 셋업 전
-  ✅ Story 파일 구조
-  ✅ args / argTypes / controls
-
-여유 있을 때
-  Radix UI Input 소스 코드 읽기
-  Headless UI 소스 코드 읽기
-```
-
----
-
 ## 참고
 
 - [Radix UI Primitives](https://www.radix-ui.com/primitives) — 헤드리스 패턴 레퍼런스
 - [shadcn/ui GitHub](https://github.com/shadcn-ui/ui) — 헤드리스 위에 스타일 입히는 방식
-- [Storybook 공식문서 - Writing Stories](https://storybook.js.org/docs/writing-stories)
 - [MDN - ARIA](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) — 접근성 속성 레퍼런스
-  fl


### PR DESCRIPTION
리뷰어가 '학생 노트'가 아니라 '판단 기록'으로 읽도록 교과서 도입부 제거, 결정을 앞으로.

- 003: 유틸타입 정의 튜토리얼 제거 → '결정 1/결정 2' 재구성 (277→216)
- 006: '📚 사전 학습' → 결정 프레임, Storybook 튜토리얼·학습 우선순위 제거 (302→240)
- 002: 패턴 정의 3개 H1 → 단일 결정 문서로 통합