### PR TITLE
chore: lint/test/typecheck 병렬 실행으로 변경

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -16,16 +16,16 @@
       ]
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": []
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": []
     },
     "check-types": {
-      "dependsOn": ["^check-types"]
+      "dependsOn": []
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": []
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## Summary
- lint/test/check-types/typecheck의 `dependsOn`을 `["^task"]`에서 빈 배열로 변경
- 빌드와 달리 패키지 간 의존 관계가 없으므로 병렬 실행되도록 수정

## Test plan
- [ ] `pnpm lint` 정상 실행 확인
- [ ] `pnpm test` 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)