### PR TITLE
style: 반응형 디자인 개선

### DIFF
--- a/apps/web/src/app/(main)/collections/CollectionsContent.tsx
+++ b/apps/web/src/app/(main)/collections/CollectionsContent.tsx
@@ -41,7 +41,7 @@ export function CollectionsContent() {
             className="py-32"
           />
         ) : isLoading ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 6 }).map((_, i) => (
               <div
                 key={i}
@@ -64,7 +64,7 @@ export function CollectionsContent() {
             </button>
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {collections.map((col) => (
               <CollectionCard
                 key={col.id}

--- a/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
+++ b/apps/web/src/app/(main)/collections/[id]/CollectionDetailContent.tsx
@@ -227,7 +227,7 @@ export function CollectionDetailContent({ id }: Props) {
             className="py-20"
           />
         ) : bkLoading ? (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <div
                 key={i}

--- a/apps/web/src/app/(public)/landing/page.tsx
+++ b/apps/web/src/app/(public)/landing/page.tsx
@@ -50,13 +50,13 @@ export default function LandingPage() {
             </span>
           </div>
 
-          <h1 className="mb-8 text-5xl leading-[1.1] font-black tracking-tight text-zinc-900 md:text-7xl dark:text-white">
+          <h1 className="mb-8 text-4xl leading-[1.1] font-black tracking-tight text-zinc-900 sm:text-5xl md:text-7xl dark:text-white">
             수많은 링크 속에서
             <br />
             <span className="text-gradient">진짜 가치</span>를 찾아내세요
           </h1>
 
-          <p className="mx-auto mb-12 max-w-2xl text-xl leading-relaxed text-zinc-600 dark:text-zinc-400">
+          <p className="mx-auto mb-12 max-w-2xl text-base leading-relaxed text-zinc-600 sm:text-xl dark:text-zinc-400">
             단순한 링크 저장을 넘어, AI가 내용을 요약하고 최적의 태그를 추천합니다. 제목이 기억 안
             나도 괜찮아요. 의미만 알아도 관련된 북마크를 찾아드려요.
           </p>
@@ -64,12 +64,12 @@ export default function LandingPage() {
           {/* 인터랙티브 버튼만 Client Component */}
           <LandingActions />
 
-          <div className="mt-16 flex items-center justify-center gap-8 text-sm font-medium text-zinc-500 dark:text-zinc-500">
+          <div className="mt-16 flex flex-col items-center justify-center gap-4 text-sm font-medium text-zinc-500 sm:flex-row sm:gap-8 dark:text-zinc-500">
             <div className="flex items-center gap-2">
               <Shield className="h-4 w-4" />
               안전한 데이터 보관
             </div>
-            <div className="h-1 w-1 rounded-full bg-zinc-300 dark:bg-zinc-700" />
+            <div className="hidden h-1 w-1 rounded-full bg-zinc-300 sm:block dark:bg-zinc-700" />
             <div className="flex items-center gap-2">
               <Zap className="h-4 w-4" />
               실시간 AI 분석
@@ -77,7 +77,7 @@ export default function LandingPage() {
           </div>
         </section>
 
-        <section className="grid gap-8 pb-32 md:grid-cols-3">
+        <section className="grid gap-8 pb-32 sm:grid-cols-2 md:grid-cols-3">
           {[
             {
               title: "스마트 AI 요약",
@@ -115,7 +115,7 @@ export default function LandingPage() {
 
         {/* 익스텐션 섹션 */}
         <section className="pb-32">
-          <div className="from-brand-primary/5 to-brand-accent/5 dark:from-brand-primary/10 dark:to-brand-accent/10 relative overflow-hidden rounded-3xl border border-zinc-100 bg-gradient-to-br via-white p-12 dark:border-zinc-800 dark:via-zinc-900">
+          <div className="from-brand-primary/5 to-brand-accent/5 dark:from-brand-primary/10 dark:to-brand-accent/10 relative overflow-hidden rounded-3xl border border-zinc-100 bg-gradient-to-br via-white p-6 sm:p-8 md:p-12 dark:border-zinc-800 dark:via-zinc-900">
             <div className="bg-brand-primary/10 pointer-events-none absolute top-0 right-0 -z-0 h-64 w-64 translate-x-1/3 -translate-y-1/3 rounded-full blur-3xl" />
 
             <div className="relative flex flex-col items-start gap-10 md:flex-row md:items-center">
@@ -126,7 +126,7 @@ export default function LandingPage() {
                     Chrome Extension
                   </span>
                 </div>
-                <h2 className="mb-4 text-3xl font-black tracking-tight text-zinc-900 md:text-4xl dark:text-white">
+                <h2 className="mb-4 text-2xl font-black tracking-tight text-zinc-900 sm:text-3xl md:text-4xl dark:text-white">
                   브라우징 중에도
                   <br />
                   <span className="text-gradient">원클릭으로 저장</span>

--- a/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
@@ -132,7 +132,7 @@ export const BookmarkDetailPanel = ({
         role="dialog"
         aria-modal="true"
         aria-label="북마크 상세"
-        className={`fixed top-0 right-0 z-50 flex h-full w-full max-w-md flex-col bg-white shadow-2xl transition-transform duration-300 ease-in-out dark:bg-zinc-900 ${
+        className={`fixed top-0 right-0 z-50 flex h-full w-full flex-col bg-white shadow-2xl transition-transform duration-300 ease-in-out md:max-w-md dark:bg-zinc-900 ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
       >
@@ -181,7 +181,7 @@ export const BookmarkDetailPanel = ({
                       src={bookmark.thumbnailUrl}
                       alt={bookmark.title}
                       fill
-                      sizes="448px"
+                      sizes="(max-width: 768px) 100vw, 448px"
                       className="object-cover"
                     />
                   </div>


### PR DESCRIPTION
## 📝 무엇을 만들었나요

모바일/태블릿/큰 화면 대응이 부족했던 부분의 반응형 개선

## 🚀 주요 변경 사항

- [x] BookmarkDetailPanel: 모바일 풀스크린, md 이상에서 max-w-md 패널로 전환
- [x] 랜딩 페이지: sm 단계 타이포/그리드/패딩 전환 추가 (text-4xl→sm:5xl→md:7xl)
- [x] 랜딩 기능 카드: 1열→sm:2열→md:3열 그리드 전환 추가
- [x] 익스텐션 섹션: 모바일 패딩 축소 (p-6 sm:p-8 md:p-12)
- [x] 컬렉션 목록/상세: xl에서 4열 그리드 추가

## 🧠 기술적 의사결정

- 기존 md 한 단계 점프 → sm 중간 단계 추가로 모바일↔태블릿 전환을 부드럽게 처리
- BookmarkDetailPanel은 모바일에서 max-w-md 제거하여 화면 전체 활용 (md 이상에서만 패널 형태)

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수 (상위 레이어 → 하위 레이어만 import)
- [x] 타입 에러 없음 (`pnpm typecheck`)
- [x] 린트 통과 (`pnpm lint`)
- [x] 불필요한 console.log 제거