### PR TITLE
test: E2E 크리티컬 플로우 테스트 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,31 @@ jobs:
       - name: 테스트 실행 (unit/통합)
         run: pnpm --filter @smart-bookmark/web test:unit
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    if: github.base_ref == 'main'
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY: placeholder-anon-key
+      SUPABASE_SERVICE_ROLE_KEY: placeholder-service-role-key
+      GEMINI_API_KEY: placeholder-gemini-key
+      RESEND_API_KEY: re_placeholder
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Playwright 브라우저 설치
+        run: pnpm --filter @smart-bookmark/web exec playwright install --with-deps chromium
+      - name: E2E 테스트 실행
+        run: pnpm --filter @smart-bookmark/web test:e2e --project=chromium
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/apps/web/e2e/bookmark-save.spec.ts
+++ b/apps/web/e2e/bookmark-save.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("북마크 저장 크리티컬 플로우", () => {
+  test.beforeEach(async ({ page }) => {
+    // 게스트로 메인 페이지 접근
+    await page
+      .context()
+      .addCookies([{ name: "is_guest", value: "true", domain: "localhost", path: "/" }]);
+    await page.goto("/");
+  });
+
+  test("북마크 추가 버튼 클릭 → 모달 열림 → URL 입력 → 저장 → 카드 표시", async ({ page }) => {
+    // 1. 추가 버튼 클릭
+    const addButton = page.getByRole("button", { name: /북마크 추가/i });
+    await addButton.click();
+
+    // 2. 모달 열림 확인
+    await expect(page.getByText("새 북마크 추가")).toBeVisible();
+
+    // 3. URL 입력
+    const urlInput = page.getByPlaceholder("https://example.com");
+    await urlInput.fill("https://react.dev");
+
+    // 4. 저장 클릭
+    const saveButton = page.getByRole("button", { name: /북마크 저장/i });
+    await saveButton.click();
+
+    // 5. 모달 닫힘
+    await expect(page.getByText("새 북마크 추가")).not.toBeVisible();
+
+    // 6. 카드 표시 (crawling 상태로 즉시 표시됨)
+    await expect(page.getByText("https://react.dev")).toBeVisible();
+  });
+
+  test("빈 URL 저장 시도 → 에러 메시지 표시", async ({ page }) => {
+    const addButton = page.getByRole("button", { name: /북마크 추가/i });
+    await addButton.click();
+
+    // URL 비운 채로 저장 시도
+    const saveButton = page.getByRole("button", { name: /북마크 저장/i });
+    await saveButton.click();
+
+    // 모달이 닫히지 않고 에러 표시
+    await expect(page.getByText("새 북마크 추가")).toBeVisible();
+  });
+
+  test("잘못된 URL 입력 → 에러 메시지 표시", async ({ page }) => {
+    const addButton = page.getByRole("button", { name: /북마크 추가/i });
+    await addButton.click();
+
+    const urlInput = page.getByPlaceholder("https://example.com");
+    await urlInput.fill("not-a-valid-url");
+
+    const saveButton = page.getByRole("button", { name: /북마크 저장/i });
+    await saveButton.click();
+
+    // 모달이 닫히지 않음 (에러 상태)
+    await expect(page.getByText("새 북마크 추가")).toBeVisible();
+  });
+
+  test("모달 ESC로 닫기", async ({ page }) => {
+    const addButton = page.getByRole("button", { name: /북마크 추가/i });
+    await addButton.click();
+
+    await expect(page.getByText("새 북마크 추가")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+
+    await expect(page.getByText("새 북마크 추가")).not.toBeVisible();
+  });
+});

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("랜딩 페이지 크리티컬 플로우", () => {
+  test("랜딩 페이지 로드 → 핵심 요소 표시", async ({ page }) => {
+    await page.goto("/landing");
+
+    // 로고
+    await expect(page.getByText("SmartMark")).toBeVisible();
+
+    // 히어로 텍스트
+    await expect(page.getByText("진짜 가치")).toBeVisible();
+
+    // CTA 버튼
+    await expect(page.getByRole("link", { name: /시작하기/i })).toBeVisible();
+
+    // 기능 카드 3개
+    await expect(page.getByText("스마트 AI 요약")).toBeVisible();
+    await expect(page.getByText("AI 의미 검색")).toBeVisible();
+    await expect(page.getByText("태그 기반 필터")).toBeVisible();
+  });
+
+  test("시작하기 버튼 → 로그인 페이지 이동", async ({ page }) => {
+    await page.goto("/landing");
+
+    const ctaButton = page.getByRole("link", { name: /시작하기/i });
+    await ctaButton.click();
+
+    await page.waitForURL("**/login");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("이미 계정이 있으신가요 → 로그인 페이지 이동", async ({ page }) => {
+    await page.goto("/landing");
+
+    const loginLink = page.getByText("이미 계정이 있으신가요?");
+    await loginLink.click();
+
+    await page.waitForURL("**/login");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("모바일 뷰포트에서 랜딩 페이지 깨지지 않음", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto("/landing");
+
+    // 핵심 요소 모바일에서도 표시
+    await expect(page.getByText("SmartMark")).toBeVisible();
+    await expect(page.getByText("진짜 가치")).toBeVisible();
+    await expect(page.getByRole("link", { name: /시작하기/i })).toBeVisible();
+
+    // 수평 스크롤 없음 확인
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const viewportWidth = await page.evaluate(() => window.innerWidth);
+    expect(bodyWidth).toBeLessThanOrEqual(viewportWidth + 1);
+  });
+});


### PR DESCRIPTION
## 📝 무엇을 만들었나요

크리티컬 유저 플로우(북마크 저장, 랜딩 페이지) E2E 테스트 추가 및 CI 파이프라인 연동

## 🚀 주요 변경 사항

- [x] 북마크 저장 E2E: 모달 열기→URL 입력→저장→카드 표시, 잘못된 URL 에러, ESC 닫기
- [x] 랜딩 페이지 E2E: 핵심 요소 표시, 로그인 이동, 모바일 수평 스크롤 없음
- [x] CI: dev→main PR에서만 E2E 실행 (Playwright chromium)

## 🧠 기술적 의사결정

- E2E는 dev→main PR에서만 실행 — 매 PR마다 돌리면 CI가 느려지므로 프로덕션 배포 전 최종 검증 용도로만 사용
- chromium 단일 브라우저 — 크로스 브라우저 테스트는 현재 규모에서 불필요, 필요 시 확장 가능

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수 (상위 레이어 → 하위 레이어만 import)
- [x] 타입 에러 없음 (`pnpm typecheck`)
- [x] 린트 통과 (`pnpm lint`)
- [x] 불필요한 console.log 제거