### PR TITLE
feat: 성능 데모 개선 (최대 10,000개 + 측정 팁)

### DIFF
--- a/apps/web/src/app/demo/DemoContent.tsx
+++ b/apps/web/src/app/demo/DemoContent.tsx
@@ -7,11 +7,11 @@ import { makeFakeBookmarks } from "@/features/bookmark/lib/fakeBookmarks";
 import { VirtualBookmarkGrid } from "@/features/bookmark/ui/VirtualBookmarkGrid";
 import { BookmarkList } from "@/features/bookmark/ui/BookmarkList";
 
-const COUNT_PRESETS = [500, 2000, 5000];
+const COUNT_PRESETS = [2000, 5000, 10000];
 
 export function DemoContent() {
   const params = useSearchParams();
-  const count = Math.min(Math.max(Number(params.get("count")) || 2000, 1), 5000);
+  const count = Math.min(Math.max(Number(params.get("count")) || 2000, 1), 10000);
   const virtual = params.get("virtual") !== "off";
 
   // 메모리에서만 생성 — DB/localStorage 저장 없음 (순수 렌더 성능 측정용)
@@ -29,6 +29,11 @@ export function DemoContent() {
           <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
             가짜 데이터를 메모리에서 생성해 렌더 성능만 측정합니다 (DB 저장 없음). 아래 토글로{" "}
             <b>가상화 ON/OFF</b>를 직접 비교해 보세요.
+          </p>
+          <p className="mt-1 text-xs text-zinc-400">
+            💡 빠른 기기에선 체감이 작을 수 있어요. DevTools <b>Elements</b>에서 DOM 노드 수(ON은
+            수십 개, OFF는 전체)를 비교하거나, <b>Performance → CPU 6x 스로틀</b>로 느린 기기를
+            시뮬레이션하면 차이가 확실합니다.
           </p>
 
           <div className="mt-3 flex flex-wrap items-center gap-2 text-sm">


### PR DESCRIPTION
빠른 기기 체감 대응: 개수 상한 10,000으로 확대 + DOM 노드 수/CPU 스로틀 측정 팁 안내.