### PR TITLE
fix: 네이버 블로그 크롤링 실패 (iframe 래퍼 → 본문 URL 치환)

### DIFF
--- a/apps/web/src/server/services/crawler.service.test.ts
+++ b/apps/web/src/server/services/crawler.service.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { resolveCrawlUrl } from "./crawler.service";
+
+describe("resolveCrawlUrl — iframe 래퍼 사이트 크롤링 대상 치환", () => {
+  it("네이버 블로그 글 URL을 PostView로 치환한다", () => {
+    expect(resolveCrawlUrl("https://blog.naver.com/megkdk0723/223256292281")).toBe(
+      "https://blog.naver.com/PostView.naver?blogId=megkdk0723&logNo=223256292281"
+    );
+  });
+
+  it("모바일 네이버 블로그도 치환한다", () => {
+    expect(resolveCrawlUrl("https://m.blog.naver.com/someone/1234567890")).toBe(
+      "https://blog.naver.com/PostView.naver?blogId=someone&logNo=1234567890"
+    );
+  });
+
+  it("끝 슬래시가 있어도 치환한다", () => {
+    expect(resolveCrawlUrl("https://blog.naver.com/abc_def-1/111/")).toBe(
+      "https://blog.naver.com/PostView.naver?blogId=abc_def-1&logNo=111"
+    );
+  });
+
+  it("글 번호가 아닌 네이버 블로그 경로(홈 등)는 치환하지 않는다", () => {
+    expect(resolveCrawlUrl("https://blog.naver.com/megkdk0723")).toBe(
+      "https://blog.naver.com/megkdk0723"
+    );
+    expect(resolveCrawlUrl("https://blog.naver.com/PostView.naver?blogId=a&logNo=1")).toBe(
+      "https://blog.naver.com/PostView.naver?blogId=a&logNo=1"
+    );
+  });
+
+  it("네이버 블로그가 아닌 URL은 그대로 반환한다", () => {
+    expect(resolveCrawlUrl("https://example.com/megkdk0723/223256292281")).toBe(
+      "https://example.com/megkdk0723/223256292281"
+    );
+    expect(resolveCrawlUrl("https://blog.naver.com.evil.com/a/1")).toBe(
+      "https://blog.naver.com.evil.com/a/1"
+    );
+  });
+
+  it("파싱 불가능한 문자열은 그대로 반환한다", () => {
+    expect(resolveCrawlUrl("not-a-url")).toBe("not-a-url");
+  });
+});

--- a/apps/web/src/server/services/crawler.service.ts
+++ b/apps/web/src/server/services/crawler.service.ts
@@ -1,6 +1,27 @@
 import * as cheerio from "cheerio";
 import { validateSsrf, SsrfError } from "@/shared/lib/validateSsrf";
 
+/**
+ * 일부 사이트는 본문이 iframe 래퍼 뒤에 있어 원 URL로는 내용을 얻을 수 없다.
+ * 네이버 블로그가 대표적: blog.naver.com/{blogId}/{logNo} 는 JS frameset 래퍼(약 3KB,
+ * og 태그·본문 없음)이고 실제 본문·og는 PostView.naver 에 있다.
+ * → 크롤링 "대상" URL만 치환한다 (북마크에 저장되는 원본 URL은 그대로).
+ */
+export function resolveCrawlUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname === "blog.naver.com" || u.hostname === "m.blog.naver.com") {
+      const m = u.pathname.match(/^\/([A-Za-z0-9_-]+)\/(\d+)\/?$/);
+      if (m) {
+        return `https://blog.naver.com/PostView.naver?blogId=${m[1]}&logNo=${m[2]}`;
+      }
+    }
+  } catch {
+    // URL 파싱 실패 시 원본 유지 — 이후 validateSsrf가 걸러낸다
+  }
+  return url;
+}
+
 export type CrawlerErrorCode =
   | "FETCH_FAILED"
   | "PARSE_FAILED"
@@ -32,7 +53,7 @@ export class CrawlerService {
 
   async crawl(url: string, attempt: number = 1): Promise<CrawlResult> {
     try {
-      const { response, finalUrl } = await this.safeFetch(url);
+      const { response, finalUrl } = await this.safeFetch(resolveCrawlUrl(url));
 
       if (!response.ok) {
         return this.handleRetry(url, attempt, "FETCH_FAILED");


### PR DESCRIPTION
## 📝 무엇을 만들었나요

네이버 블로그 북마크 저장 시 AI 요약이 실패하던 문제 수정.

## 🐛 원인

`blog.naver.com/{id}/{글번호}` 는 JS frameset 래퍼(~3KB)로 **og 태그·본문이 전혀 없음** (실측: og 0개, `<p>` 본문 0개). 실제 본문은 iframe 뒤 `PostView.naver`에 있어(284KB, og·본문 정상) 크롤러가 빈 데이터를 얻고 AI가 요약할 재료가 없었음.

## 🚀 수정

- `resolveCrawlUrl()` — 네이버 블로그 글 URL 패턴이면 크롤링 **대상만** PostView로 치환 (북마크에 저장되는 원본 URL은 유지)
- 유사 도메인(`blog.naver.com.evil.com`)·블로그 홈 경로는 미치환
- 웹·익스텐션 파이프라인 모두 crawlerService를 쓰므로 둘 다 수정됨

## ✅ 체크리스트

- [x] 단위 테스트 6개 (치환/미치환/보안 케이스)
- [x] 타입 에러 없음