### PR TITLE
fix: 태그/임베딩 저장 RLS 위반 (upsert DO UPDATE 경로 제거)

### DIFF
--- a/apps/web/src/app/api/extension/_lib/pipeline.ts
+++ b/apps/web/src/app/api/extension/_lib/pipeline.ts
@@ -35,20 +35,22 @@ export async function runPipeline(supabase: SupabaseClient, bookmarkId: string, 
   const summary = aiData.summary ?? "";
   const tags: string[] = aiData.tags ?? [];
 
-  // 태그 저장 — 태그별 순차 왕복(2N) 대신 배치 upsert 2회로 처리
+  // 태그 저장 — 배치 처리. 충돌 시 DO NOTHING(ignoreDuplicates): DO UPDATE 경로는
+  // tags에 UPDATE RLS 정책이 없어 저장 전체가 실패한다. (DO NOTHING은 기존 행 id를
+  // 반환하지 않으므로 이름으로 일괄 재조회)
   if (tags.length > 0) {
-    const { data: tagRows } = await supabase
-      .from("tags")
-      .upsert(
-        tags.map((name) => ({ name })),
-        { onConflict: "name" }
-      )
-      .select("id");
+    await supabase.from("tags").upsert(
+      tags.map((name) => ({ name })),
+      { onConflict: "name", ignoreDuplicates: true }
+    );
+
+    const { data: tagRows } = await supabase.from("tags").select("id").in("name", tags);
 
     if (tagRows && tagRows.length > 0) {
-      await supabase
-        .from("bookmark_tags")
-        .upsert(tagRows.map((t) => ({ bookmark_id: bookmarkId, tag_id: t.id })));
+      await supabase.from("bookmark_tags").upsert(
+        tagRows.map((t) => ({ bookmark_id: bookmarkId, tag_id: t.id })),
+        { ignoreDuplicates: true }
+      );
     }
   }
 
@@ -62,9 +64,13 @@ export async function runPipeline(supabase: SupabaseClient, bookmarkId: string, 
         taskType: TaskType.RETRIEVAL_DOCUMENT,
         outputDimensionality: 3072,
       } as Parameters<typeof embeddingModel.embedContent>[0]);
+      // onConflict를 bookmark_id(unique)로 명시 — 재저장 시 갱신 경로는 migration 006 정책 필요
       await supabase
         .from("embeddings")
-        .upsert({ bookmark_id: bookmarkId, embedding: embeddingResult.embedding.values });
+        .upsert(
+          { bookmark_id: bookmarkId, embedding: embeddingResult.embedding.values },
+          { onConflict: "bookmark_id" }
+        );
     }
   } catch (e) {
     console.error("[Pipeline] 임베딩 오류:", e);

--- a/apps/web/src/entities/bookmark/api/supabase.repository.ts
+++ b/apps/web/src/entities/bookmark/api/supabase.repository.ts
@@ -204,9 +204,11 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
    * @description 임베딩 벡터를 embeddings 테이블에 저장합니다
    */
   async saveEmbedding(bookmarkId: string, embedding: number[]): Promise<void> {
+    // onConflict를 bookmark_id(unique)로 명시 — 기본값(PK id)은 매번 새 id로 insert를 시도해
+    // 재저장 시 충돌이 해소되지 않는다. 갱신 경로는 소유자 한정 UPDATE 정책(migration 006) 필요.
     const { error } = await supabase
       .from("embeddings")
-      .upsert({ bookmark_id: bookmarkId, embedding });
+      .upsert({ bookmark_id: bookmarkId, embedding }, { onConflict: "bookmark_id" });
 
     if (error) {
       throw new BookmarkError(
@@ -218,25 +220,49 @@ export class SupabaseBookmarkRepository implements BookmarkRepository {
   }
 
   /**
-   * @description 태그 이름 목록을 tags 테이블에 upsert하고 bookmark_tags에 연결합니다
+   * @description 태그 이름 목록을 tags 테이블에 생성(없는 것만)하고 bookmark_tags에 연결합니다.
+   * 충돌 시 DO NOTHING(ignoreDuplicates) — DO UPDATE 경로는 tags에 UPDATE RLS 정책이 없어
+   * "row-level security policy (USING expression)" 위반으로 저장 전체가 실패한다.
    */
   async insertTags(bookmarkId: string, tagNames: string[]): Promise<void> {
-    for (const name of tagNames) {
-      const { data: tag, error: upsertError } = await supabase
-        .from("tags")
-        .upsert({ name }, { onConflict: "name" })
-        .select("id")
-        .single();
+    const { error: upsertError } = await supabase.from("tags").upsert(
+      tagNames.map((name) => ({ name })),
+      { onConflict: "name", ignoreDuplicates: true }
+    );
 
-      if (upsertError || !tag) {
-        throw new BookmarkError(
-          BookmarkErrorCode.TAG_INSERT_FAILED,
-          `태그 추가 실패: ${upsertError?.message ?? "태그 생성 결과가 없습니다."}`,
-          upsertError
-        );
-      }
+    if (upsertError) {
+      throw new BookmarkError(
+        BookmarkErrorCode.TAG_INSERT_FAILED,
+        `태그 추가 실패: ${upsertError.message}`,
+        upsertError
+      );
+    }
 
-      await supabase.from("bookmark_tags").upsert({ bookmark_id: bookmarkId, tag_id: tag.id });
+    // DO NOTHING은 기존 행을 반환하지 않으므로 이름으로 id를 일괄 조회
+    const { data: tagRows, error: selectError } = await supabase
+      .from("tags")
+      .select("id")
+      .in("name", tagNames);
+
+    if (selectError || !tagRows || tagRows.length === 0) {
+      throw new BookmarkError(
+        BookmarkErrorCode.TAG_INSERT_FAILED,
+        `태그 조회 실패: ${selectError?.message ?? "태그 조회 결과가 없습니다."}`,
+        selectError
+      );
+    }
+
+    const { error: linkError } = await supabase.from("bookmark_tags").upsert(
+      tagRows.map((t) => ({ bookmark_id: bookmarkId, tag_id: t.id })),
+      { ignoreDuplicates: true }
+    );
+
+    if (linkError) {
+      throw new BookmarkError(
+        BookmarkErrorCode.TAG_INSERT_FAILED,
+        `태그 연결 실패: ${linkError.message}`,
+        linkError
+      );
     }
   }
 

--- a/supabase/migrations/006_embeddings_update_policy.sql
+++ b/supabase/migrations/006_embeddings_update_policy.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- 006. embeddings UPDATE 정책 추가 (소유자 한정)
+-- ============================================================
+-- 배경: saveEmbedding이 upsert(onConflict: bookmark_id)로 동작하는데,
+-- 기존 행이 있는 재저장(재크롤·재시도) 시 DO UPDATE 경로를 타면서
+-- UPDATE 정책이 없어 "row-level security policy" 위반으로 실패했다.
+--
+-- tags / bookmark_tags 는 앱에서 DO NOTHING(ignoreDuplicates)으로 바꿔
+-- UPDATE 권한 자체가 필요 없으므로 정책을 넓히지 않는다. (RLS 최소 권한 유지)
+
+drop policy if exists "embeddings_update" on embeddings;
+create policy "embeddings_update" on embeddings for update
+  using (
+    exists (
+      select 1 from bookmarks
+      where bookmarks.id = embeddings.bookmark_id
+        and bookmarks.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from bookmarks
+      where bookmarks.id = embeddings.bookmark_id
+        and bookmarks.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## 📝 무엇을 만들었나요

북마크 저장 시 "AI 요약 실패"로 기록되던 진짜 원인 수정 — 요약은 성공했지만 **태그/임베딩 저장이 RLS에 막혀** 전체가 실패 처리되던 회귀.

## 🐛 원인 (로컬 dev 로그로 확정)

- `tags` 배치 upsert(`onConflict: "name"`)가 **기존 태그와 충돌 시 DO UPDATE 경로**를 탐 → tags엔 UPDATE RLS 정책이 없음 → `row-level security policy (USING expression)` 위반 → 저장 전체 실패. N+1 개선(#59) 때 유입된 회귀.
- `embeddings` upsert는 onConflict 미지정(PK id 기준)이라 재저장 시 충돌 해소 불가 + UPDATE 정책 부재.

## 🚀 수정

- [x] tags/bookmark_tags: **DO NOTHING(ignoreDuplicates)** — UPDATE 권한 자체가 불필요 (RLS 최소권한 유지). 기존 행 id는 이름으로 일괄 재조회
- [x] insertTags 태그별 루프(N+1) → 배치 3쿼리
- [x] saveEmbedding `onConflict: "bookmark_id"` 명시
- [x] **migration 006**: embeddings 소유자 한정 UPDATE 정책 (⚠️ Supabase 적용 필요)
- [x] 웹 repository + 익스텐션 pipeline 동일 수정

## ✅ 체크리스트

- [x] 타입 에러 없음, 단위/통합 201개 통과
- [ ] ⚠️ **migration 006을 프로덕션 Supabase에 적용 필요** (미적용 시 임베딩 "갱신"만 실패, 신규 insert는 정상)