### PR TITLE
fix: embeddings 정책/스키마 드리프트 정리 (임베딩 저장이 조용히 실패하던 문제)

### DIFF
--- a/apps/web/src/features/bookmark/model/bookmark.service.ts
+++ b/apps/web/src/features/bookmark/model/bookmark.service.ts
@@ -93,11 +93,17 @@ export class BookmarkService {
 
   /**
    * @description 임베딩 벡터를 저장합니다. (회원 전용)
+   * 파이프라인 단계마다 세션을 재확인하므로, 저장은 게스트(localStorage)로 됐는데
+   * 임베딩 시점에 세션이 살아나면(만료→자동갱신 등) Supabase에 없는 북마크 id로
+   * insert를 시도해 RLS 위반이 난다 → 소유 확인 후에만 저장한다.
    */
   async saveEmbedding(bookmarkId: string, embedding: number[]): Promise<void> {
     const repo = await this.getRepository();
     if (repo instanceof SupabaseBookmarkRepository) {
-      await repo.saveEmbedding(bookmarkId, embedding);
+      const owned = await repo.findById(bookmarkId);
+      if (owned) {
+        await repo.saveEmbedding(bookmarkId, embedding);
+      }
     }
   }
 

--- a/supabase/migrations/007_fix_embeddings_policy_drift.sql
+++ b/supabase/migrations/007_fix_embeddings_policy_drift.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- 007. embeddings 정책/스키마 드리프트 정리
+-- ============================================================
+-- 배경 (실측: pg_policies / information_schema / pg_get_functiondef):
+--   실제 DB에는 초기 세팅의 구식 정책 "Users access own embeddings"(ALL,
+--   auth.uid() = user_id)와 legacy user_id 컬럼이 남아 있었고,
+--   001의 embeddings_select/insert/delete 정책은 미적용 상태였다.
+--   앱은 insert 시 user_id를 보내지 않으므로(001 스키마 기준) 모든 임베딩
+--   INSERT가 RLS WITH CHECK 위반으로 조용히 실패해 왔다.
+--
+-- 판정 근거: match_bookmarks는 bookmarks 조인(b.user_id = p_user_id)으로
+--   소유권을 판정하며 embeddings.user_id를 사용하지 않는다.
+--   → 001 설계(북마크 소유권 기반 EXISTS)로 통일하고 legacy를 제거한다.
+
+-- 1) 구식 ALL 정책 제거
+drop policy if exists "Users access own embeddings" on embeddings;
+
+-- 2) 001 기준 정책 적용 (update는 006에서 이미 생성됨)
+drop policy if exists "embeddings_select" on embeddings;
+create policy "embeddings_select" on embeddings for select
+  using (
+    exists (
+      select 1 from bookmarks
+      where bookmarks.id = embeddings.bookmark_id
+        and bookmarks.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "embeddings_insert" on embeddings;
+create policy "embeddings_insert" on embeddings for insert
+  with check (
+    exists (
+      select 1 from bookmarks
+      where bookmarks.id = embeddings.bookmark_id
+        and bookmarks.user_id = auth.uid()
+    )
+  );
+
+drop policy if exists "embeddings_delete" on embeddings;
+create policy "embeddings_delete" on embeddings for delete
+  using (
+    exists (
+      select 1 from bookmarks
+      where bookmarks.id = embeddings.bookmark_id
+        and bookmarks.user_id = auth.uid()
+    )
+  );
+
+-- 3) legacy 컬럼 제거 (이를 참조하던 정책을 1)에서 먼저 제거했으므로 안전)
+alter table embeddings drop column if exists user_id;


### PR DESCRIPTION
## 📝 무엇을 만들었나요

임베딩 INSERT가 RLS 위반으로 **조용히 전부 실패**하던 문제의 근본 수정.

## 🐛 원인 (라이브 DB 실측으로 확정)

- 실제 DB엔 초기 세팅의 구식 정책 `"Users access own embeddings"`(ALL, `auth.uid() = user_id`) + legacy `user_id` 컬럼이 남아 있었고, 001의 `embeddings_select/insert/delete`는 **미적용** (스키마 드리프트)
- 앱은 001 스키마 기준이라 `user_id`를 안 보냄 → WITH CHECK 항상 실패 → fire-and-forget이라 티 안 나게 실패 누적 (신규 북마크가 시맨틱 검색에서 누락)

## 🚀 수정

- [x] **migration 007**: 구식 정책·legacy 컬럼 제거, 001 설계(북마크 소유권 EXISTS)로 통일 — `match_bookmarks`가 bookmarks 조인으로 소유권 판정함을 확인 후 결정
- [x] `saveEmbedding` 소유 가드 — 세션 만료→갱신 타이밍에 게스트 저장 북마크 id로 회원 임베딩 insert가 나가던 케이스 차단

## ✅ 체크리스트

- [x] 타입/테스트 201개 통과
- [ ] ⚠️ **migration 007을 Supabase에 적용 필요**