### PR TITLE
fix: 클릭 요소 cursor pointer 일괄 적용 (Tailwind v4 preflight 대응)

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -89,6 +89,16 @@
       color: #fafafa;
     }
   }
+
+  /* Tailwind v4 preflight는 button 기본 cursor를 pointer로 주지 않는다(v3와 다름).
+     클릭 가능한 요소 전체에 일괄 적용 — 개별 컴포넌트에 cursor-pointer를 흩뿌리지 않는다. */
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  label[for],
+  select,
+  summary {
+    cursor: pointer;
+  }
 }
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## 📝 무엇을 만들었나요

클릭 가능한 요소에 마우스 포인터가 안 뜨던 문제를 전역 한 곳에서 해결.

## 🐛 원인

Tailwind **v4 preflight는 v3와 달리 `button`에 `cursor: pointer` 기본값을 주지 않음**.

## 🚀 변경

- [x] globals.css base에 `button:not(:disabled)`, `[role=button]`, `label[for]`, `select`, `summary` 일괄 pointer — 컴포넌트마다 클래스 흩뿌리지 않음
- [x] 비버튼 클릭 요소 전수 점검: 카드류는 전부 `<button>`이거나(전역 커버) 이미 조건부 `cursor-pointer` 처리됨(BookmarkCard·Tag)

## ✅ 체크리스트

- [x] 프로덕션 빌드 통과