### PR TITLE
fix: 챗 페이지 빈 화면 스크롤 제거 (헤더 h-16 고정 + dvh)

### DIFF
--- a/apps/web/e2e/header.spec.ts
+++ b/apps/web/e2e/header.spec.ts
@@ -39,8 +39,9 @@ test.describe("Header 깜빡임 테스트", () => {
 
     await page.goto("/");
 
-    // 게스트님 텍스트가 보여야 함
-    await expect(page.getByText("게스트님")).toBeVisible();
+    // 게스트 아바타(사용자 메뉴)가 보여야 함 — 닉네임 텍스트는 lg 미만에서 숨기는 디자인이라
+    // 뷰포트 무관한 아바타 버튼으로 검증 (Mobile Chrome 프로젝트 포함)
+    await expect(page.getByRole("button", { name: "사용자 메뉴" })).toBeVisible();
     // 로그인 버튼은 없어야 함
     await expect(page.getByText("로그인", { exact: true })).not.toBeVisible();
   });

--- a/apps/web/src/features/chat/ui/ChatContent.tsx
+++ b/apps/web/src/features/chat/ui/ChatContent.tsx
@@ -100,8 +100,9 @@ export function ChatContent() {
   const isEmpty = messages.length === 0;
 
   return (
-    <div className="min-h-[calc(100vh-4rem)] bg-zinc-50 font-sans text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
-      <div className="mx-auto flex h-[calc(100vh-4rem)] max-w-3xl flex-col px-4">
+    // 100dvh: 모바일 주소창 수축/확장에도 실제 보이는 높이 기준. 헤더는 h-16 고정(border 포함) 전제
+    <div className="min-h-[calc(100dvh-4rem)] bg-zinc-50 font-sans text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
+      <div className="mx-auto flex h-[calc(100dvh-4rem)] max-w-3xl flex-col px-4">
         <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto py-8">
           {isEmpty ? (
             <div className="flex h-full flex-col items-center justify-center gap-6 text-center">

--- a/apps/web/src/widgets/layout/Header.tsx
+++ b/apps/web/src/widgets/layout/Header.tsx
@@ -181,9 +181,10 @@ export const Header = ({ initialUser }: { initialUser: User | null }) => {
   const isOnBookmarks = pathname === "/bookmarks";
 
   return (
-    <header className="sticky top-0 z-50 border-b border-zinc-200 bg-white/80 backdrop-blur-md dark:border-zinc-800 dark:bg-black/80">
+    // h-16 고정(border 포함) — 레이아웃 스켈레톤과 챗 페이지의 calc(100dvh-4rem)가 이 높이를 전제한다
+    <header className="sticky top-0 z-50 h-16 border-b border-zinc-200 bg-white/80 backdrop-blur-md dark:border-zinc-800 dark:bg-black/80">
       <nav
-        className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8"
+        className="mx-auto flex h-full max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8"
         aria-label="Global"
       >
         {/* 왼쪽: 로고 + 데스크톱 검색 */}


### PR DESCRIPTION
## 📝 무엇을 만들었나요

챗 페이지에서 내용이 없어도 살짝 생기던 페이지 스크롤 제거.

## 🐛 원인

헤더가 `py-4` 기반이라 실제 **~73px**인데, 챗 컨테이너와 레이아웃 스켈레톤은 **h-16(64px)을 전제** → `73 + (100vh−64) = 100vh + 9px` 스크롤. 스켈레톤(64px)→실제 헤더(73px) 전환 시 **미세 CLS**도 동반.

## 🚀 변경

- [x] Header `h-16` 고정(border 포함) — 스켈레톤과 일치 (CLS 제거 보너스)
- [x] ChatContent `100vh → 100dvh` (모바일 주소창 대응)
- [x] header.spec 게스트 검증을 아바타 버튼(role)로 — 닉네임은 lg 미만 숨김 디자인이라 Mobile Chrome에서 **원래부터 실패하던** 테스트 (CI는 `--project=chromium`만 돌아 미노출)

## ✅ 체크리스트

- [x] header/qa-header/pipeline-failure E2E **24 passed** (chromium+Mobile Chrome, workers=1)
- [x] 타입 에러 없음
- [ ] 참고(후속 후보): CI E2E에 Mobile Chrome 프로젝트 추가 여부 — 런타임 증가와 트레이드오프