### PR TITLE
fix: 카드 썸네일 비율 og:image 표준(1.91:1) 통일

### DIFF
--- a/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
@@ -51,7 +51,7 @@ export const BookmarkCard = ({
       className={`group relative flex h-full w-full flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white transition-all ${isPending ? "cursor-wait opacity-90" : "cursor-pointer hover:-translate-y-1 hover:shadow-2xl"} focus-visible:ring-brand-primary shadow-sm focus-visible:ring-2 focus-visible:outline-none dark:border-zinc-800 dark:bg-zinc-900`}
     >
       {/* 1. Thumbnail Area */}
-      <div className="relative aspect-[16/10] w-full overflow-hidden bg-zinc-50 dark:bg-zinc-800/50">
+      <div className="relative aspect-[1.91/1] w-full overflow-hidden bg-zinc-50 dark:bg-zinc-800/50">
         {isCrawling ? (
           <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-zinc-100 to-zinc-200 dark:from-zinc-800 dark:to-zinc-700">
             <div className="flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 shadow-xl dark:bg-zinc-900/90">

--- a/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkDetailPanel.tsx
@@ -176,7 +176,7 @@ export const BookmarkDetailPanel = ({
               {/* sticky: 썸네일 + 제목 */}
               <div className="sticky top-0 z-10 bg-white dark:bg-zinc-900">
                 {bookmark.thumbnailUrl && (
-                  <div className="relative aspect-[16/9] w-full overflow-hidden bg-zinc-100 dark:bg-zinc-800">
+                  <div className="relative aspect-[1.91/1] w-full overflow-hidden bg-zinc-100 dark:bg-zinc-800">
                     <Image
                       src={bookmark.thumbnailUrl}
                       alt={bookmark.title}

--- a/apps/web/src/features/bookmark/ui/BookmarkList.tsx
+++ b/apps/web/src/features/bookmark/ui/BookmarkList.tsx
@@ -35,7 +35,7 @@ export const BookmarkList = ({
             key={i}
             className="flex h-72 flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
           >
-            <div className="aspect-[16/10] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
+            <div className="aspect-[1.91/1] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
             <div className="flex flex-1 flex-col gap-3 p-6">
               <div className="h-5 w-3/4 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
               <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />

--- a/apps/web/src/widgets/bookmark/RecentBookmarkSlider.tsx
+++ b/apps/web/src/widgets/bookmark/RecentBookmarkSlider.tsx
@@ -43,7 +43,7 @@ export const RecentBookmarkSlider = ({
                 key={i}
                 className="w-[85vw] flex-none overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white shadow-sm sm:w-[calc(50%-10px)] lg:w-[calc(33.333%-14px)] dark:border-zinc-800 dark:bg-zinc-900"
               >
-                <div className="aspect-[16/10] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
+                <div className="aspect-[1.91/1] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
                 <div className="flex flex-col gap-3 p-6">
                   <div className="h-5 w-3/4 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
                   <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />


### PR DESCRIPTION
## 📝 무엇을 만들었나요

카드 썸네일이 좌우로 잘리던 문제 — 컨테이너 비율을 og:image 표준(1.91:1)으로 통일.

## 🚀 주요 변경 사항

- [x] 카드 16/10(1.6:1) 컨테이너가 표준 og:image(1200×630=1.91:1)를 object-cover로 좌우 ~16% 크롭 → 텍스트형 OG 이미지 첫 글자가 잘리던 원인
- [x] 카드·리스트/슬라이더 스켈레톤·상세패널을 1.91:1로 통일 (트위터/슬랙 링크 카드와 동일 관례)

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음
- [x] 린트 통과