### PR TITLE
fix: 로딩 스켈레톤 실제 카드와 동형화 (로드 시 점프 제거)

### DIFF
--- a/apps/web/src/features/bookmark/ui/BookmarkList.tsx
+++ b/apps/web/src/features/bookmark/ui/BookmarkList.tsx
@@ -30,16 +30,26 @@ export const BookmarkList = ({
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {/* 실제 카드와 동형 구조(이미지 비율·여백·줄 수) — 고정 높이(h-72)는 로드 완료 시 레이아웃 점프(CLS)를 만든다 */}
         {Array.from({ length: 4 }).map((_, i) => (
           <div
             key={i}
-            className="flex h-72 flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
+            className="flex flex-col overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
           >
             <div className="aspect-[1.91/1] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
-            <div className="flex flex-1 flex-col gap-3 p-6">
-              <div className="h-5 w-3/4 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
-              <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
-              <div className="h-3 w-1/2 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+            <div className="flex flex-1 flex-col p-6">
+              <div className="mb-3 space-y-2">
+                <div className="h-5 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                <div className="h-5 w-2/3 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+              </div>
+              <div className="mb-6 flex-1 space-y-2">
+                <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                <div className="h-3 w-3/5 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+              </div>
+              <div className="flex gap-2">
+                <div className="h-6 w-16 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+                <div className="h-6 w-12 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+              </div>
             </div>
           </div>
         ))}

--- a/apps/web/src/widgets/bookmark/RecentBookmarkSlider.tsx
+++ b/apps/web/src/widgets/bookmark/RecentBookmarkSlider.tsx
@@ -44,9 +44,19 @@ export const RecentBookmarkSlider = ({
                 className="w-[85vw] flex-none overflow-hidden rounded-[2.5rem] border border-zinc-100 bg-white shadow-sm sm:w-[calc(50%-10px)] lg:w-[calc(33.333%-14px)] dark:border-zinc-800 dark:bg-zinc-900"
               >
                 <div className="aspect-[1.91/1] w-full animate-pulse bg-zinc-100 dark:bg-zinc-800" />
-                <div className="flex flex-col gap-3 p-6">
-                  <div className="h-5 w-3/4 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
-                  <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                <div className="flex flex-col p-6">
+                  <div className="mb-3 space-y-2">
+                    <div className="h-5 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                    <div className="h-5 w-2/3 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                  </div>
+                  <div className="mb-6 space-y-2">
+                    <div className="h-3 w-full animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                    <div className="h-3 w-3/5 animate-pulse rounded-full bg-zinc-100 dark:bg-zinc-800" />
+                  </div>
+                  <div className="flex gap-2">
+                    <div className="h-6 w-16 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+                    <div className="h-6 w-12 animate-pulse rounded-lg bg-zinc-100 dark:bg-zinc-800" />
+                  </div>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
## 📝 무엇을 만들었나요

로딩 스켈레톤과 실제 카드의 크기 불일치로 로드 완료 시 레이아웃이 점프하던 문제 수정.

## 🚀 주요 변경 사항

- [x] 스켈레톤 고정 높이(h-72=288px) 제거 — 실제 카드 자연 높이(~350px)와 달라 로드 순간 카드가 커지며 아래 콘텐츠가 밀렸음(CLS)
- [x] 실제 카드와 동형 구조로 재구성: 이미지 1.91:1 + 제목 2줄 + 요약 2줄 + 태그 pill, 여백 동일
- [x] 리스트·슬라이더 스켈레톤 모두 적용

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음 (`pnpm typecheck`)
- [x] 린트 통과
- [x] 불필요한 console.log 없음