### PR TITLE
feat: 썸네일 폴백 개선 (파비콘 + 도메인 고유색 이니셜)

### DIFF
--- a/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
+++ b/apps/web/src/entities/bookmark/ui/BookmarkCard.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import Image from "next/image";
-import { ExternalLink, Loader2, AlertCircle } from "lucide-react";
+import { Loader2, AlertCircle } from "lucide-react";
 import { TagGroup } from "@/shared/ui/tag/Tag";
 import { useClientNow } from "@/shared/lib/useClientNow";
 import type { Bookmark } from "../model/types";
@@ -69,20 +70,7 @@ export const BookmarkCard = ({
             className={`object-cover transition-transform duration-700 ${isProcessing ? "blur-md grayscale" : "group-hover:scale-110"}`}
           />
         ) : (
-          <div className="flex h-full w-full flex-col items-center justify-center bg-gradient-to-br from-zinc-50 to-zinc-100 dark:from-zinc-800 dark:to-zinc-900">
-            <div className="mb-2 rounded-2xl bg-white p-3 shadow-sm ring-1 ring-zinc-100 dark:bg-zinc-800 dark:ring-zinc-700">
-              <ExternalLink size={32} strokeWidth={1.5} className="text-zinc-400" />
-            </div>
-            <span className="text-[10px] font-bold tracking-widest text-zinc-400 uppercase dark:text-zinc-500">
-              {(() => {
-                try {
-                  return new URL(url).hostname;
-                } catch {
-                  return url;
-                }
-              })()}
-            </span>
-          </div>
+          <ThumbnailFallback url={url} />
         )}
 
         {isProcessing && (
@@ -222,3 +210,53 @@ export const BookmarkCard = ({
     </div>
   );
 };
+
+/**
+ * og:image가 없을 때의 썸네일 폴백 — 도메인 해시 기반 고유 색 + 파비콘(실패 시 이니셜).
+ * 폴백 카드들이 똑같은 회색으로 나열되면 목록 스캔이 어려워지므로 도메인마다 색·글자를 다르게 한다.
+ */
+function domainHue(host: string): number {
+  let h = 0;
+  for (let i = 0; i < host.length; i++) h = (h * 31 + host.charCodeAt(i)) % 360;
+  return h;
+}
+
+function ThumbnailFallback({ url }: { url: string }) {
+  const [faviconFailed, setFaviconFailed] = useState(false);
+
+  let hostname = "";
+  try {
+    hostname = new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    hostname = url;
+  }
+  const hue = domainHue(hostname);
+
+  return (
+    <div
+      className="flex h-full w-full flex-col items-center justify-center gap-2.5 px-4"
+      style={{ backgroundColor: `hsl(${hue} 70% 50% / 0.13)` }}
+    >
+      {hostname && !faviconFailed ? (
+        <div className="rounded-2xl bg-white/85 p-2.5 shadow-sm dark:bg-zinc-900/70">
+          <Image
+            src={`https://www.google.com/s2/favicons?domain=${hostname}&sz=64`}
+            alt=""
+            width={36}
+            height={36}
+            unoptimized
+            className="rounded-lg"
+            onError={() => setFaviconFailed(true)}
+          />
+        </div>
+      ) : (
+        <span className="text-4xl font-black" style={{ color: `hsl(${hue} 55% 45%)` }}>
+          {(hostname.charAt(0) || "?").toUpperCase()}
+        </span>
+      )}
+      <span className="max-w-full truncate text-xs font-bold tracking-wide text-zinc-500 dark:text-zinc-400">
+        {hostname}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📝 무엇을 만들었나요

og:image가 없는 카드의 썸네일 폴백을 파비콘 + 도메인 고유색 이니셜 타일로 개선.

## 🚀 주요 변경 사항

- [x] 도메인 해시 기반 고유색 배경 — 폴백 카드들이 똑같은 회색으로 나열돼 스캔이 어렵던 문제 해소 (같은 도메인 = 항상 같은 색)
- [x] 파비콘 표시(구글 s2) → 로드 실패 시 도메인 이니셜 타이포로 자연 강등
- [x] `ExternalLink`(↗) 아이콘 제거 — "열기" 의미라 "미리보기 없음"과 어긋났음
- [x] 도메인명 10px 대문자 → text-xs + truncate 가독성 개선

## ✅ 체크리스트

- [x] FSD 레이어 규칙 준수
- [x] 타입 에러 없음 (`pnpm typecheck`)
- [x] 린트 통과
- [x] 카드 단위 테스트 7개 통과