### PR TITLE
ci: dev 진입을 PR 전용으로 게이팅

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
 name: CI
 
+# dev는 직접 push 금지(브랜치 보호 enforce_admins) → 진입은 PR로만.
+# 따라서 CI는 PR에서만 돌린다. PR은 up-to-date(strict) 병합 프리뷰를 검증하므로
+# 머지 후 재실행(on.push)은 중복이라 두지 않는다.
 on:
-  push:
-    branches:
-      - dev
   pull_request:
     branches:
       - main
       - dev
+
+# 같은 ref에 새 커밋이 push되면 진행 중인 옛 CI run은 취소한다(자원 낭비 방지).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:


### PR DESCRIPTION
## 목적
dev 브랜치를 required check 통과한 PR로만 진입 가능하도록 게이팅.
기존에는 dev 직접 push가 admin 우회로 허용돼 required check가 실제 게이트로 작동하지 않았음.

## 변경
- `ci.yml`: `on.push[dev]` 트리거 제거 → CI는 PR에서만 실행
- `ci.yml`: `concurrency` 추가 → 같은 ref 새 push 시 진행 중 run 취소
- (별도) dev 브랜치 보호 `enforce_admins: true` → 관리자도 직접 push 불가

## 검증
이 PR 자체가 새 게이트를 통과하는 첫 케이스 — 3개 required check(Lint/Test/Build) 통과 후 머지.